### PR TITLE
feat: Add migrated trading bot from Duality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# ignore default nested dependencies storage
+repos/
+
+# ignore cosmopark files from https://github.com/neutron-org/neutron-integration-tests/blob/main/.gitignore
+keystore.db
+contracts/artifacts/
+contracts/*.wasm
+
+# IDEs
+*.iml
+.idea
+.DS_Store
+*_action.json
+.vscode
+
+write-file-atomic*
+junit.xml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+# allow this container to contact other Docker containers through the docker CLI
+FROM docker:24.0.5-cli
+
+# add additional dependencies for the testnet scripts
+RUN apk add bash curl grep openssl jq;
+
+WORKDIR /workspace/neutron
+COPY scripts /workspace/neutron/scripts
+
+CMD bash ./scripts/run_trade_bot.sh

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 REPOS_DIR ?= ./repos
 SETUP_DIR ?= $(REPOS_DIR)/neutron-integration-tests/setup
 COMPOSE ?= docker-compose
-NEUTRON_VERSION ?= v2.0.0
+NEUTRON_VERSION ?= v2.0.2
 GAIA_VERSION ?= v14.1.0
 
 

--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,6 @@ start-trade-bot: build-trade-bot
 stop-trade-bot:
 	@$(COMPOSE) down -t0 --remove-orphans -v
 
-run-trade-bot: build-trade-bot
+run-trade-bot: stop-trade-bot build-trade-bot
 	@$(COMPOSE) up --abort-on-container-exit || true
 	$(MAKE) stop-trade-bot

--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,7 @@ start-trade-bot: build-trade-bot
 stop-trade-bot:
 	@$(COMPOSE) down -t0 --remove-orphans -v
 
+run-trade-bot: export TRADE_DURATION_SECONDS ?= 60
 run-trade-bot: stop-trade-bot build-trade-bot
 	@$(COMPOSE) up --abort-on-container-exit || true
 	$(MAKE) stop-trade-bot

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ build-relayer: init-dir init-relayer
 build-all: init-all build-gaia build-neutron build-hermes build-relayer
 
 
-# --- docker usage commands ---
+# --- cosmopark commands from neutron-integrated-tests repo ---
 
 start-cosmopark: build-neutron build-relayer
 	@$(COMPOSE) -f $(SETUP_DIR)/docker-compose.yml up -d
@@ -79,3 +79,19 @@ start-neutron-node:
 clean:
 	@echo "Removing previous testing data"
 	-@docker volume rm neutron-testing-data
+
+
+# --- new docker compose network commands ---
+
+build-trade-bot:
+	@$(COMPOSE) build
+
+start-trade-bot: build-trade-bot
+	@$(COMPOSE) up
+
+stop-trade-bot:
+	@$(COMPOSE) down -t0 --remove-orphans -v
+
+run-trade-bot: build-trade-bot
+	@$(COMPOSE) up --abort-on-container-exit || true
+	$(MAKE) stop-trade-bot

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,70 @@
+REPOS_DIR ?= ./repos
+SETUP_DIR ?= $(REPOS_DIR)/neutron-integration-tests/setup
+COMPOSE ?= docker-compose
+NEUTRON_VERSION ?= v2.0.0
+GAIA_VERSION ?= v14.1.0
+
+init-dir:
+ifeq (,$(wildcard $(REPOS_DIR)))
+	mkdir $(REPOS_DIR)
+endif
+
+init-neutron:
+ifeq (,$(wildcard $(REPOS_DIR)/neutron))
+	cd $(REPOS_DIR) && git clone -b $(NEUTRON_VERSION) https://github.com/neutron-org/neutron.git
+else
+	cd $(REPOS_DIR)/neutron && git fetch origin $(NEUTRON_VERSION) && git checkout $(NEUTRON_VERSION)
+endif
+
+init-hermes:
+ifeq (,$(wildcard $(REPOS_DIR)/neutron-integration-tests))
+	cd $(REPOS_DIR) && git clone https://github.com/neutron-org/neutron-integration-tests.git
+else
+	cd $(REPOS_DIR)/neutron-integration-tests && git pull
+endif
+
+init-relayer:
+ifeq (,$(wildcard $(REPOS_DIR)/neutron-query-relayer))
+	cd $(REPOS_DIR) && git clone https://github.com/neutron-org/neutron-query-relayer.git
+else
+	cd $(REPOS_DIR)/neutron-query-relayer && git pull
+endif
+
+init-gaia:
+ifeq (,$(wildcard $(REPOS_DIR)/gaia))
+	cd $(REPOS_DIR) && git clone -b $(GAIA_VERSION) https://github.com/cosmos/gaia.git
+else
+	cd $(REPOS_DIR)/gaia && git fetch origin $(GAIA_VERSION) && git checkout $(GAIA_VERSION)
+endif
+
+init-all: init-dir init-neutron init-hermes init-relayer init-gaia
+
+build-gaia: init-dir init-gaia
+	@docker buildx build --load --build-context app=$(REPOS_DIR)/gaia --build-context setup=$(REPOS_DIR)/neutron/network -t gaia-node -f $(SETUP_DIR)/dockerbuilds/Dockerfile.gaia --build-arg BINARY=gaiad .
+
+build-neutron: init-dir init-neutron
+	cd $(REPOS_DIR)/neutron && $(MAKE) build-docker-image
+
+build-hermes: init-dir init-hermes
+	cd $(SETUP_DIR) && $(MAKE) build-hermes
+
+build-relayer: init-dir init-relayer
+	cd $(REPOS_DIR)/neutron-query-relayer && $(MAKE) build-docker
+
+build-all: init-all build-gaia build-neutron build-hermes build-relayer
+
+start-cosmopark: build-neutron build-relayer
+	@$(COMPOSE) -f $(SETUP_DIR)/docker-compose.yml up -d
+
+start-cosmopark-no-rebuild:
+	@$(COMPOSE) -f $(SETUP_DIR)/docker-compose.yml up -d
+
+stop-cosmopark:
+	@$(COMPOSE) -f $(SETUP_DIR)/docker-compose.yml down -t0 --remove-orphans -v
+
+start-neutron-node:
+	@$(COMPOSE) -f $(SETUP_DIR)/docker-compose.yml up neutron-node
+
+clean:
+	@echo "Removing previous testing data"
+	-@docker volume rm neutron-testing-data

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,13 @@
+# this file is based on https://github.com/neutron-org/neutron-integration-tests/blob/dd5e0cf609432c970ba432a84eb53bcfef961652/setup/Makefile
+
 REPOS_DIR ?= ./repos
 SETUP_DIR ?= $(REPOS_DIR)/neutron-integration-tests/setup
 COMPOSE ?= docker-compose
 NEUTRON_VERSION ?= v2.0.0
 GAIA_VERSION ?= v14.1.0
+
+
+# --- repo init commands ---
 
 init-dir:
 ifeq (,$(wildcard $(REPOS_DIR)))
@@ -39,6 +44,9 @@ endif
 
 init-all: init-dir init-neutron init-hermes init-relayer init-gaia
 
+
+# --- docker build commands ---
+
 build-gaia: init-dir init-gaia
 	@docker buildx build --load --build-context app=$(REPOS_DIR)/gaia --build-context setup=$(REPOS_DIR)/neutron/network -t gaia-node -f $(SETUP_DIR)/dockerbuilds/Dockerfile.gaia --build-arg BINARY=gaiad .
 
@@ -52,6 +60,9 @@ build-relayer: init-dir init-relayer
 	cd $(REPOS_DIR)/neutron-query-relayer && $(MAKE) build-docker
 
 build-all: init-all build-gaia build-neutron build-hermes build-relayer
+
+
+# --- docker usage commands ---
 
 start-cosmopark: build-neutron build-relayer
 	@$(COMPOSE) -f $(SETUP_DIR)/docker-compose.yml up -d

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ start-trade-bot: build-trade-bot
 stop-trade-bot:
 	@$(COMPOSE) down -t0 --remove-orphans -v
 
-run-trade-bot: export TRADE_DURATION_SECONDS ?= 60
-run-trade-bot: stop-trade-bot build-trade-bot
+test-trade-bot: export TRADE_DURATION_SECONDS ?= 60
+test-trade-bot: stop-trade-bot build-trade-bot
 	@$(COMPOSE) up --abort-on-container-exit || true
 	$(MAKE) stop-trade-bot

--- a/README.md
+++ b/README.md
@@ -47,3 +47,13 @@ All docker-compose env vars are able to be set in both `make start-trade-bot` an
 
 eg. `make start-trade-bot TRADE_FREQUENCY_SECONDS=0 TRADE_DURATION_SECONDS=600`
 will start a persistent chain that for the first ~10min will generate ~500txs.
+
+# Troubleshooting
+
+The chain should be visible at http://localhost:26657 and REST at http://localhost:1317.
+
+If you cannot contact these addresses from within a different Docker service (such as a local indexer), try using:
+```
+RPC_API=http://host.docker.internal:26657
+REST_API=http://host.docker.internal:1317
+```

--- a/README.md
+++ b/README.md
@@ -1,1 +1,49 @@
-# dex-trading-bot
+# A Dex Trading Bot
+
+## Requirements
+- git
+- Docker
+- make
+
+## Get Started
+
+To run the bot, you will first need a chain to run the bot against,
+locally this should be a single dockerized neutron node
+- `make build-neutron`
+
+To run the default setup of a single neutron-node chain and a single trading bot:
+- `make start-trade-bot`
+
+This composed neutron chain and trading bot network will persist until you call:
+- `make stop-trade-bot`
+
+### Test runs (start+stop)
+You can test a chain and bot(s) configuration and exit with cleanup in one step using:
+- `make test-trade-bot`
+
+However the default settings are quite conservative, and won't product many txs.
+A larger test which should generate approximately ~500txs txs in ~10 minutes could be done with:
+- `make test-trade-bot TRADE_FREQUENCY_SECONDS=0 TRADE_DURATION_SECONDS=180`
+
+This can be ideal for CI type testing of a service that depends on Dex transactions on a Neutron chain.
+But if you want the chain to persist after the trades are completed (with a finite `TRADE_DURATION_SECONDS`),
+then `make start-trade-bot` should be used instead.
+
+## Available options
+
+All docker-compose env vars are able to be set in both `make start-trade-bot` and `make test-trade-bot`
+- Chain variables
+    - `CHAIN_ID`: the chain ID
+    - `LOG_LEVEL`: which logs should be visible from the chain
+    - `GRPC_PORT`: the GRPC port number
+    - `GRPC_WEB`: the GRPC-web port number
+- Trading bot variables:
+    - `RPC_ADDRESS`: RPC address of chain
+    - `API_ADDRESS`: API address of chain
+    - `TRADE_DURATION_SECONDS`: how long trades should occur for
+    - `TRADE_FREQUENCY_SECONDS`: how many seconds to delay between trades on a bot
+    - `GAS_ADJUSTMENT`: how much more than the base estimated gas price to pay for each tx
+    - `GAS_PRICES`: calculate how many fees to pay from this fraction of gas
+
+eg. `make start-trade-bot TRADE_FREQUENCY_SECONDS=0 TRADE_DURATION_SECONDS=600`
+will start a persistent chain that for the first ~10min will generate ~500txs.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
         echo "Starting $$CHAINID..."
         neutrond start                             \
             --log_level "$$LOG_LEVEL"              \
-            --home "./data/$$CHAINID"              \
+            --home "$$CHAIN_DIR"                   \
             --pruning=nothing                      \
             --grpc.address="0.0.0.0:$$GRPCPORT"    \
             --grpc-web.address="0.0.0.0:$$GRPCWEB"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,41 @@
+version: '3.8'
+services:
+  neutron-node:
+    image: neutron-node
+    container_name: neutron-node
+    volumes:
+      - data:/opt/neutron/data
+    ports:
+      - 1317:1317
+      - 26657:26657
+      - 26656:26656
+      - 8090:9090
+    environment:
+      - RUN_BACKGROUND=0
+    networks:
+      - neutron-testing
+
+  dex-trading-bot:
+    build:
+      context: .
+    depends_on:
+      - "neutron-node"
+    environment:
+      - CHAIN_ID=${CHAIN_ID:-test-1}
+      - NEUTROND_NODE=neutron-node
+      - RPC_ADDRESS=${RPC_ADDRESS:-http://neutron-node:26657}
+      - API_ADDRESS=${API_ADDRESS:-http://neutron-node:1317}
+      - TRADE_DURATION_SECONDS=${TRADE_DURATION_SECONDS:-}
+      - TRADE_FREQUENCY_SECONDS=${TRADE_FREQUENCY_SECONDS:-60}
+    networks:
+      - neutron-testing
+
+volumes:
+  data:
+    name: neutron-testing-data
+    external: false
+
+networks:
+  neutron-testing:
+    name: neutron-testing
+    external: false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,19 @@ version: '3.8'
 services:
   neutron-node:
     image: neutron-node
+    command: >
+      /bin/bash -c '
+        #!/bin/bash
+        set -e
+
+        # initialize the chain state
+        bash /opt/neutron/network/init.sh
+        bash /opt/neutron/network/init-neutrond.sh
+        bash /opt/neutron/network/start.sh
+
+        # keep container running after TRADE_DURATION_SECONDS has been reached
+        tail -f /dev/null
+      '
     container_name: neutron-node
     volumes:
       - data:/opt/neutron/data
@@ -11,7 +24,7 @@ services:
       - 26656:26656
       - 8090:9090
     environment:
-      - RUN_BACKGROUND=0
+      - RUN_BACKGROUND=1
     networks:
       - neutron-testing
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,8 @@ services:
       - API_ADDRESS=${API_ADDRESS:-http://neutron-node:1317}
       - TRADE_DURATION_SECONDS=${TRADE_DURATION_SECONDS:-}
       - TRADE_FREQUENCY_SECONDS=${TRADE_FREQUENCY_SECONDS:-60}
+      - GAS_ADJUSTMENT=${GAS_ADJUSTMENT:-1.5}
+      - GAS_PRICES=${GAS_PRICES:-0.0025untrn}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,11 @@ services:
         bash /opt/neutron/network/init.sh
         bash /opt/neutron/network/init-neutrond.sh
 
+        # allow CORS requests from dev localhost origin
+        BASE_DIR=/opt/neutron/data
+        CHAIN_DIR="$$BASE_DIR/$$CHAINID"
+        sed -i -e "s/cors_allowed_origins = \[\]/cors_allowed_origins = $$CORS_ALLOWED_ORIGINS/g" "$$CHAIN_DIR/config/config.toml"
+
         # run chain
         echo "Starting $$CHAINID..."
         neutrond start                             \
@@ -33,6 +38,7 @@ services:
       - CHAINID=${CHAIN_ID:-test-1}
       - GRPCPORT=${GRPC_PORT:-9090}
       - GRPCWEB=${GRPC_WEB:-9091}
+      - CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS:-["*"]}
     networks:
       - neutron-testing
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,8 @@ services:
       - API_ADDRESS=${API_ADDRESS:-http://neutron-node:1317}
       - TRADE_DURATION_SECONDS=${TRADE_DURATION_SECONDS:-}
       - TRADE_FREQUENCY_SECONDS=${TRADE_FREQUENCY_SECONDS:-60}
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
     networks:
       - neutron-testing
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,7 @@ services:
       - API_ADDRESS=${API_ADDRESS:-http://neutron-node:1317}
       - TRADE_DURATION_SECONDS=${TRADE_DURATION_SECONDS:-}
       - TRADE_FREQUENCY_SECONDS=${TRADE_FREQUENCY_SECONDS:-60}
-      - GAS_ADJUSTMENT=${GAS_ADJUSTMENT:-1.5}
+      - GAS_ADJUSTMENT=${GAS_ADJUSTMENT:-2}
       - GAS_PRICES=${GAS_PRICES:-0.0025untrn}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,10 +10,15 @@ services:
         # initialize the chain state
         bash /opt/neutron/network/init.sh
         bash /opt/neutron/network/init-neutrond.sh
-        bash /opt/neutron/network/start.sh
 
-        # keep container running after TRADE_DURATION_SECONDS has been reached
-        tail -f /dev/null
+        # run chain
+        echo "Starting $$CHAINID..."
+        neutrond start                             \
+            --log_level "$$LOG_LEVEL"              \
+            --home "./data/$$CHAINID"              \
+            --pruning=nothing                      \
+            --grpc.address="0.0.0.0:$$GRPCPORT"    \
+            --grpc-web.address="0.0.0.0:$$GRPCWEB"
       '
     container_name: neutron-node
     volumes:
@@ -24,7 +29,10 @@ services:
       - 26656:26656
       - 8090:9090
     environment:
-      - RUN_BACKGROUND=1
+      - LOG_LEVEL=${LOG_LEVEL:-warn}
+      - CHAINID=${CHAIN_ID:-test-1}
+      - GRPCPORT=${GRPC_PORT:-9090}
+      - GRPCWEB=${GRPC_WEB:-9091}
     networks:
       - neutron-testing
 

--- a/scripts/check_chain_status.sh
+++ b/scripts/check_chain_status.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+set -e
+
+RPC_ADDRESS=$1
+CHAIN_ID=$2
+
+echo "Connecting to testnet: $RPC_ADDRESS ..."
+# check if we can get information from the testnet
+abci_info=$(
+    curl \
+        --connect-timeout 1 \
+        --max-time 3 \
+        --retry 30 \
+        --retry-connrefused \
+        --retry-delay 1 \
+        --silent \
+        $RPC_ADDRESS/abci_info
+)
+if [[ "$( echo $abci_info | jq -r ".result.response.data" )" != "neutrond" ]]
+then
+    echo "Could not establish connection to Neutron testnet"
+    exit 1
+fi
+
+echo "Neutron testnet available"
+
+# check that the expected chain is found if specified
+if [ ! -z "$CHAIN_ID" ]
+then
+    status=$( curl --connect-timeout 1 --max-time 3 --retry 30 --retry-connrefused --retry-delay 1 -s $RPC_ADDRESS/status )
+    found_network=$( echo $status | jq -r ".result.node_info.network" )
+    if [[ "$found_network" == "$CHAIN_ID" ]]
+    then
+        echo "Neutron testnet has expected chain: $CHAIN_ID"
+    else
+        echo "Neutron testnet has unexpected chain: $found_network (expected $CHAIN_ID)"
+        exit 1
+    fi
+fi
+
+# wait for testnet to be ready (block must be started for txs to be processed)
+latest_height=0
+while [[ "$latest_height" -lt 1 ]]
+do
+    latest_block=$(
+        curl \
+            --connect-timeout 1 \
+            --max-time 3 \
+            --retry 3 \
+            --retry-connrefused \
+            --retry-delay 1 \
+            --silent \
+            $RPC_ADDRESS/status
+    )
+    latest_height="$( echo $latest_block | jq -r '.result.sync_info.latest_block_height' )"
+done
+
+echo "Neutron testnet ready"

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -3,7 +3,7 @@ set -e
 
 # alias neutrond to a specific Docker neutrond
 neutrond() {
-    docker exec ${NEUTROND_NODE:-leader} neutrond "$@"
+    docker exec $NEUTROND_NODE neutrond "$@"
 }
 
 createAndFundUser() {

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -3,7 +3,7 @@ set -e
 
 # alias neutrond to a specific Docker neutrond
 neutrond() {
-    docker exec $NEUTROND_NODE neutrond "$@"
+    docker exec $NEUTROND_NODE neutrond --home /opt/neutron/data/$CHAIN_ID "$@"
 }
 
 createAndFundUser() {

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+set -e
+
+# alias neutrond to a specific Docker neutrond
+neutrond() {
+    docker exec ${NEUTROND_NODE:-leader} neutrond "$@"
+}
+
+createAndFundUser() {
+    tokens=$1
+    # create person name
+    person=$(openssl rand -hex 12)
+    # create person's new account (with a random name and set passphrase)
+    # the --no-backup flag only prevents output of the new key to the terminal
+    neutrond keys add $person --no-backup <<< $'asdfasdf\nn' >/dev/null
+    # send funds from frugal faucet friend (Fred)
+    tx_hash=$(
+        neutrond tx bank send \
+            $( neutrond keys show fred --output json | jq -r .address ) \
+            $( neutrond keys show $person --output json | jq -r .address ) \
+            $tokens \
+            --broadcast-mode sync \
+            --output json \
+            --yes \
+            | jq -r '.txhash'
+    )
+    # get tx result for msg
+    tx_result=$(bash ./scripts/test_helpers.sh waitForTxResult "$API_ADDRESS" "$tx_hash")
+
+    # return only person name for test usage
+    echo "$person"
+}
+
+throwOnTxError() {
+    test_name=$1
+    tx_result=$2
+    tx_code=$( echo $tx_result | jq -r .tx_response.code )
+    if [[ "$tx_code" == "" ]]
+    then
+        echo "$test_name: error (tx_reponse code not found) with tx_hash: \"$tx_hash\""
+        exit 1
+    elif [[ "$tx_code" != "0" ]]
+    then
+        tx_hash=$( echo $tx_result | jq -r .tx_response.txhash )
+        tx_log=$( echo $tx_result | jq -r .tx_response.raw_log )
+        echo "$test_name: error ($tx_code) at $tx_hash: $tx_log"
+        exit $tx_code
+    fi
+}
+
+waitForTxResult() {
+    api=$1
+    hash=$2
+    echo "making request: for result of tx hash $api/cosmos/tx/v1beta1/txs/$hash" > /dev/stderr
+    echo "$(
+      curl \
+      --connect-timeout 10 \
+      --fail \
+      --retry 30 \
+      --retry-connrefused \
+      --retry-max-time 30 \
+      --retry-delay 1 \
+      --retry-all-errors \
+      -s $api/cosmos/tx/v1beta1/txs/$hash
+    )"
+}
+
+
+# below code is taken from https://stackoverflow.com/questions/8818119/how-can-i-run-a-function-from-a-script-in-command-line#16159057
+
+# Check if the function exists (bash specific)
+if declare -f "$1" > /dev/null
+then
+    # call arguments verbatim
+    "$@"
+else
+    # Show a helpful error
+    echo "'$1' is not a known function name" >&2
+    exit 1
+fi

--- a/scripts/run_trade_bot.sh
+++ b/scripts/run_trade_bot.sh
@@ -1,0 +1,297 @@
+#!/bin/bash
+set -e
+
+# alias neutrond to a specific Docker neutrond
+neutrond() {
+  docker exec ${NEUTROND_NODE:-leader} neutrond "$@"
+}
+
+# set which node we will talk to
+CHAIN_ID="${CHAIN_ID:-$(neutrond config chain-id)}"
+RPC_ADDRESS="${RPC_ADDRESS:-$(neutrond config node)}"
+
+echo "CHAIN_ID: $CHAIN_ID"
+echo "NODE: $RPC_ADDRESS"
+
+# check that NODE and CHAIN_ID details are correct
+SCRIPTPATH="$( dirname "$(readlink "$BASH_SOURCE" || echo "$BASH_SOURCE")" )"
+bash $SCRIPTPATH/check_chain_status.sh $RPC_ADDRESS $CHAIN_ID
+
+# define the person to trade with as the "trader" account
+person="trader"
+
+# add some helper functions to generate chain CLI args
+count=100; # should be divisible by 4
+function join_with_comma {
+  local IFS=,
+  echo "$*"
+}
+function repeat_with_comma {
+  repeated=()
+  for (( i=0; i<$count/2; i++ ))
+  do
+    repeated+=( $1 )
+  done
+  join_with_comma "${repeated[@]}"
+}
+function get_token_1_reserves_amount {
+  amount=$1
+  index=$2;
+  # note: this calculation is inaccurate, share amount is not a pure value
+  # so the reserves are not always proportional to the shares amount
+  # this fact should either be considered, or tick liquidity should be tightly controlled
+  # to avoid the cases where reserves are not proportional to the shares amount
+  echo " $amount / (1.0001 ^ $index) " \
+    | bc -l \
+    | awk '{printf("%.0f\n",$0+1)}' # round up only (in case we don't create enough reserves)
+}
+
+token_pairs=( '["stake","token"]' '["tokenA","tokenB"]' '["tokenB","tokenC"]' '["tokenA","tokenC"]' )
+
+# create initial tick array outside of max price amplitude
+fee_options=( 1 5 20 100 )
+max_tick_index=12000
+indexes0=()
+indexes1=()
+amounts0=()
+amounts1=()
+fees=()
+amount=1000000000 # use a base billion tokens, assume coins have 6 decimal places
+for (( i=0; i<$count/4; i++ ))
+do
+  index=$(( $RANDOM % $max_tick_index ))
+  indexes0+=( $(( -$max_tick_index - $index )) -$index )
+  indexes1+=( $index $(( $index + $max_tick_index )) )
+  # calculate reserve amounts to add that will equal the same amount of shares
+  amounts0+=( $amount $amount )
+  amounts1+=( $( get_token_1_reserves_amount $amount $index ) )
+  amounts1+=( $( get_token_1_reserves_amount $amount $(( $index + $max_tick_index )) ) )
+  fee=${fee_options[$(( $RANDOM % 4 ))]}
+  fees+=( $fee $fee )
+done
+
+for token_pair in ${token_pairs[@]}
+do
+  token0=$( echo $token_pair | jq -r .[0] )
+  token1=$( echo $token_pair | jq -r .[1] )
+  echo "making deposit: initial ticks for $token0 and $token1"
+  # apply an amount to all tick indexes specified
+  neutrond tx dex deposit \
+    `# receiver` \
+    "$(neutrond keys show "$person" --output json | jq -r .address)" \
+    `# token-a` \
+    $token0 \
+    `# token-b` \
+    $token1 \
+    `# list of amount-0` \
+    "$(repeat_with_comma "$amount"),$(repeat_with_comma "0")" \
+    `# list of amount-1` \
+    "$(repeat_with_comma "0"),$(join_with_comma "${amounts1[@]}")" \
+    `# list of tickIndexInToOut` \
+    "[$(join_with_comma "${indexes0[@]}"),$(join_with_comma "${indexes1[@]}")]" \
+    `# list of fees` \
+    "$(join_with_comma "${fees[@]}"),$(join_with_comma "${fees[@]}")" \
+    `# disable_autoswap` \
+    "$(repeat_with_comma "false"),$(repeat_with_comma "false")" \
+    `# options` \
+    --from $person --yes --output json --broadcast-mode sync --gas auto --gas-adjustment 1.5 \
+    | jq -r '.txhash' \
+    | xargs -I{} bash $SCRIPTPATH/helpers.sh waitForTxResult "$API_ADDRESS" "{}" \
+    | jq -r '"[ tx code: \(.tx_response.code) ] [ tx hash: \(.tx_response.txhash) ]"' \
+    | xargs -I{} echo "{} deposited: initial $count seed liquidity ticks"
+done
+
+# approximate price with sine curves of given amplitude and period
+# macro curve oscillates over hours
+amplitude1=10000 # in ticks
+period1=3600 # in seconds
+# micro curve oscillates over minutes
+amplitude2=-2000 # in seconds
+period2=300 # in seconds
+two_pi=$( echo "scale=8; 8*a(1)" | bc -l )
+
+trade_frequency="${TRADE_FREQUENCY_SECONDS:-60}"
+max_epoch=$( [ ! -z $TRADE_DURATION_SECONDS ] && echo $(( $EPOCHSECONDS + $TRADE_DURATION_SECONDS )) || echo "" )
+max_epoch_reached=false
+
+# respond to price changes forever
+while true
+do
+  # wait a bit, maybe less than a block or enough that we don't touch a block or two
+  sleep $(( $RANDOM % $trade_frequency ))
+
+  if [ ! -z $max_epoch ] && [ $max_epoch -lt $EPOCHSECONDS ]
+  then
+    echo "TRADE_DURATION_SECONDS has been reached";
+    exit 0
+  fi
+
+  pair_index=0
+  for token_pair in ${token_pairs[@]}
+  do
+    pair_index+=1
+    token0=$( echo $token_pair | jq -r .[0] )
+    token1=$( echo $token_pair | jq -r .[1] )
+
+    # create random fee tier to use in this iteration
+    fee=${fee_options[$(( $RANDOM % 4 ))]}
+
+    # determine the new current price goal
+    current_price=$( \
+      echo " $amplitude1*s($EPOCHSECONDS / ($period1*$pair_index) * $two_pi) + $amplitude2*s($EPOCHSECONDS / $period2 * $two_pi) " \
+      | bc -l \
+      | awk '{printf("%d\n",$0+0.5)}' \
+    )
+
+    # add some randomness into price goal
+    goal_price=$(( $current_price + $RANDOM % 1000 - 500 ))
+
+    # - make a swap to get to current price
+
+    # first, find the reserves of tokens that are outside the desired price
+    # then swap those reserves
+    echo "making query: of current '$token0' ticks"
+    reserves0=$( \
+      wget -q -O - $API_ADDRESS/neutron/dex/tick_liquidity/$token0%3C%3E$token1/$token0?pagination.limit=100 \
+      | jq "[.tickLiquidity[].poolReserves | select(.key.TickIndexTakerToMaker != null) | select((.key.TickIndexTakerToMaker | tonumber) > $goal_price) | if .reservesMakerDenom == null then 0 else .reservesMakerDenom end | tonumber] | add as \$sum | if \$sum == null then 0 else \$sum end" \
+    )
+    # convert back to decimal notation with float precision
+    reserves0=$( printf '%.0f\n' "$reserves0" )
+    # use bc for aribtrary precision math comparison (non-zero result evals true)
+    if (( $(bc <<< "$reserves0 > 0") ))
+    then
+      echo "making place-limit-order: '$token1' -> '$token0'"
+      neutrond tx dex place-limit-order \
+        `# receiver` \
+        "$(neutrond keys show "$person" --output json | jq -r .address)" \
+        `# token in` \
+        $token1 \
+        `# token out` \
+        $token0 \
+        `# tickIndexInToOut (note: simply using the max tick limit so the limit is not reached)` \
+        "[$(( $goal_price * -1 ))]" \
+        `# amount in: we add an excess so we can reach the tick limit` \
+        "$(bc <<< "$reserves0 * 100")" \
+        `# order type enum see: https://github.com/duality-labs/duality/blob/v0.2.1/proto/duality/dex/tx.proto#L81-L87` \
+        `# use IMMEDIATE_OR_CANCEL which will has less strict checks that FILL_OR_KILL` \
+        IMMEDIATE_OR_CANCEL \
+        `# options` \
+        --from $person --yes --output json --broadcast-mode sync --gas auto --gas-adjustment 1.5 \
+        | jq -r '.txhash' \
+        | xargs -I{} bash $SCRIPTPATH/helpers.sh waitForTxResult $API_ADDRESS "{}" \
+        | jq -r '"[ tx code: \(.tx_response.code) ] [ tx hash: \(.tx_response.txhash) ]"' \
+        | xargs -I{} echo "{} swapped:   ticks toward target tick index of $goal_price"
+    else
+      echo "making query: of current '$token1' ticks"
+      reserves1=$( \
+        wget -q -O - $API_ADDRESS/neutron/dex/tick_liquidity/$token0%3C%3E$token1/$token1?pagination.limit=100 \
+        | jq "[.tickLiquidity[].poolReserves | select(.key.TickIndexTakerToMaker != null) | select((.key.TickIndexTakerToMaker | tonumber) < $goal_price) | if .reservesMakerDenom == null then 0 else .reservesMakerDenom end | tonumber] | add as \$sum | if \$sum == null then 0 else \$sum end" \
+      )
+      # convert back to decimal notation with float precision
+      reserves1=$( printf '%.0f\n' "$reserves1" )
+      if (( $(bc <<< "$reserves1 > 0") ))
+      then
+        echo "making place-limit-order: '$token0' -> '$token1'"
+        neutrond tx dex place-limit-order \
+          `# receiver` \
+          "$(neutrond keys show "$person" --output json | jq -r .address)" \
+          `# token in` \
+          $token0 \
+          `# token out` \
+          $token1 \
+          `# tickIndexInToOut (note: simply using the max tick limit so the limit is not reached)` \
+          "[$(( $goal_price * 1 ))]" \
+          `# amount in: we add an excess so we can reach the tick limit` \
+          "$(bc <<< "$reserves1 * 100")" \
+            `# order type enum see: https://github.com/duality-labs/duality/blob/v0.2.1/proto/duality/dex/tx.proto#L81-L87` \
+          `# use IMMEDIATE_OR_CANCEL which will has less strict checks that FILL_OR_KILL` \
+          IMMEDIATE_OR_CANCEL \
+          `# options` \
+          --from $person --yes --output json --broadcast-mode sync --gas auto --gas-adjustment 1.5 \
+          | jq -r '.txhash' \
+          | xargs -I{} bash $SCRIPTPATH/helpers.sh waitForTxResult $API_ADDRESS "{}" \
+          | jq -r '"[ tx code: \(.tx_response.code) ] [ tx hash: \(.tx_response.txhash) ]"' \
+          | xargs -I{} echo "{} swapped:   ticks toward target tick index of $goal_price"
+      fi
+    fi
+
+    # - replace the end pieces of liquidity with values closer to the current price
+
+    # determine new indexes close to the current price
+    new_index0=$(( $current_price - 1000 - $RANDOM % 1000 ))
+    new_index1=$(( $current_price + 1000 + $RANDOM % 1000 ))
+
+    # add these extra ticks to prevent swapping though all ticks errors
+    # we deposit first to lessen the cases where we have entirely one-sided liquidity
+    echo "making deposit: '$token0' + '$token1'"
+    neutrond tx dex deposit \
+      `# receiver` \
+      "$(neutrond keys show "$person" --output json | jq -r .address)" \
+      `# token-a` \
+      $token0 \
+      `# token-b` \
+      $token1 \
+      `# list of amount-0` \
+      "$amount,0" \
+      `# list of amount-1` \
+      "0,$( get_token_1_reserves_amount $amount $new_index1 )" \
+      `# list of tick-index` \
+      "[$new_index0,$new_index1]" \
+      `# list of fees` \
+      "$fee,$fee" \
+      `# disable_autoswap` \
+      false,false \
+      `# options` \
+      --from $person --yes --output json --broadcast-mode sync --gas auto --gas-adjustment 1.5 \
+      | jq -r '.txhash' \
+      | xargs -I{} bash $SCRIPTPATH/helpers.sh waitForTxResult $API_ADDRESS "{}" \
+      | jq -r '"[ tx code: \(.tx_response.code) ] [ tx hash: \(.tx_response.txhash) ]"' \
+      | xargs -I{} echo "{} deposited: new close-to-price ticks $new_index0, $new_index1"
+
+    # find reserves to withdraw
+    echo "making query: finding '$token0', '$token1' deposits to withdraw"
+    user_deposits=$( \
+      wget -q -O - $API_ADDRESS/neutron/dex/user/deposits/$( neutrond keys show $person -a )?pagination.limit=1000 \
+    )
+    sorted_user_deposits=$(
+      echo "$user_deposits" | jq "[.Deposits[] | select(.pairID.token0 == \"$token0\") | select(.pairID.token1 == \"$token1\")] | sort_by((.centerTickIndex | tonumber))"
+    )
+
+    last_liquidity0=$( echo "$sorted_user_deposits" | jq '.[0]' )
+    fee0=$( echo "$last_liquidity0" | jq -r '.fee' )
+    index0=$( echo "$last_liquidity0" | jq -r '.centerTickIndex' )
+    reserves0=$( echo "$last_liquidity0" | jq -r '.sharesOwned' )
+
+    last_liquidity1=$( echo "$sorted_user_deposits" | jq '.[-1]' )
+    fee1=$( echo "$last_liquidity1" | jq -r '.fee' )
+    index1=$( echo "$last_liquidity1" | jq -r '.centerTickIndex' )
+    reserves1=$( echo "$last_liquidity1" | jq -r '.sharesOwned' )
+
+    # withdraw the end values
+    if [ ! -z $reserves0 ] && [ ! -z $reserves1 ]
+    then
+      echo "making withdrawal: '$token0' + '$token1'"
+      neutrond tx dex withdrawal \
+        `# receiver` \
+        "$(neutrond keys show "$person" --output json | jq -r .address)" \
+        `# token-a` \
+        $token0 \
+        `# token-b` \
+        $token1 \
+        `# list of shares-to-remove` \
+        "$reserves0,$reserves1" \
+        `# list of tick-index (adjusted to center tick)` \
+        "[$index0,$index1]" \
+        `# list of fees` \
+        "$fee0,$fee1" \
+        `# options` \
+        --from $person --yes --output json --broadcast-mode sync --gas auto --gas-adjustment 1.5 \
+        | jq -r '.txhash' \
+        | xargs -I{} bash $SCRIPTPATH/helpers.sh waitForTxResult $API_ADDRESS "{}" \
+        | jq -r '"[ tx code: \(.tx_response.code) ] [ tx hash: \(.tx_response.txhash) ]"' \
+        | xargs -I{} echo "{} withdrew:  end ticks $index0, $index1"
+    fi
+
+  done
+
+done

--- a/scripts/run_trade_bot.sh
+++ b/scripts/run_trade_bot.sh
@@ -20,12 +20,14 @@ if [[ $? -ne 0 ]]; then
     echo "Cannot send neutrond commands to Neutron testnet"
     exit 1
 fi
+# set daemon calls to read test keys
+neutrond config keyring-backend test
 
 # check that NODE and CHAIN_ID details are correct
 bash $SCRIPTPATH/check_chain_status.sh $RPC_ADDRESS $CHAIN_ID
 
 # define the person to trade with as the "trader" account
-person="trader"
+person="demowallet1"
 
 # add some helper functions to generate chain CLI args
 count=100; # should be divisible by 4
@@ -53,7 +55,7 @@ function get_token_1_reserves_amount {
     | awk '{printf("%.0f\n",$0+1)}' # round up only (in case we don't create enough reserves)
 }
 
-token_pairs=( '["stake","token"]' '["tokenA","tokenB"]' '["tokenB","tokenC"]' '["tokenA","tokenC"]' )
+token_pairs=( '["uibcusdc","untrn"]' '["uibcatom","uibcusdc"]' '["uibcatom","untrn"]' )
 
 # create initial tick array outside of max price amplitude
 fee_options=( 1 5 20 100 )

--- a/scripts/run_trade_bot.sh
+++ b/scripts/run_trade_bot.sh
@@ -164,7 +164,7 @@ do
     echo "making query: of current '$token0' ticks"
     reserves0=$( \
       wget -q -O - $API_ADDRESS/neutron/dex/tick_liquidity/$token0%3C%3E$token1/$token0?pagination.limit=100 \
-      | jq "[.tickLiquidity[].poolReserves | select(.key.TickIndexTakerToMaker != null) | select((.key.TickIndexTakerToMaker | tonumber) > $goal_price) | if .reservesMakerDenom == null then 0 else .reservesMakerDenom end | tonumber] | add as \$sum | if \$sum == null then 0 else \$sum end" \
+      | jq "[.tick_liquidity[].pool_reserves | select(.key.tick_index_taker_to_maker != null) | select((.key.tick_index_taker_to_maker | tonumber) > $goal_price) | if .reserves_maker_denom == null then 0 else .reserves_maker_denom end | tonumber] | add as \$sum | if \$sum == null then 0 else \$sum end" \
     )
     # convert back to decimal notation with float precision
     reserves0=$( printf '%.0f\n' "$reserves0" )
@@ -196,7 +196,7 @@ do
       echo "making query: of current '$token1' ticks"
       reserves1=$( \
         wget -q -O - $API_ADDRESS/neutron/dex/tick_liquidity/$token0%3C%3E$token1/$token1?pagination.limit=100 \
-        | jq "[.tickLiquidity[].poolReserves | select(.key.TickIndexTakerToMaker != null) | select((.key.TickIndexTakerToMaker | tonumber) < $goal_price) | if .reservesMakerDenom == null then 0 else .reservesMakerDenom end | tonumber] | add as \$sum | if \$sum == null then 0 else \$sum end" \
+        | jq "[.tick_liquidity[].pool_reserves | select(.key.tick_index_taker_to_maker != null) | select((.key.tick_index_taker_to_maker | tonumber) < $goal_price) | if .reserves_maker_denom == null then 0 else .reserves_maker_denom end | tonumber] | add as \$sum | if \$sum == null then 0 else \$sum end" \
       )
       # convert back to decimal notation with float precision
       reserves1=$( printf '%.0f\n' "$reserves1" )
@@ -265,18 +265,18 @@ do
       wget -q -O - $API_ADDRESS/neutron/dex/user/deposits/$( neutrond keys show $person -a )?pagination.limit=1000 \
     )
     sorted_user_deposits=$(
-      echo "$user_deposits" | jq "[.Deposits[] | select(.pairID.token0 == \"$token0\") | select(.pairID.token1 == \"$token1\")] | sort_by((.centerTickIndex | tonumber))"
+      echo "$user_deposits" | jq "[.deposits[] | select(.pair_id.token0 == \"$token0\") | select(.pair_id.token1 == \"$token1\")] | sort_by((.center_tick_index | tonumber))"
     )
 
     last_liquidity0=$( echo "$sorted_user_deposits" | jq '.[0]' )
     fee0=$( echo "$last_liquidity0" | jq -r '.fee' )
-    index0=$( echo "$last_liquidity0" | jq -r '.centerTickIndex' )
-    reserves0=$( echo "$last_liquidity0" | jq -r '.sharesOwned' )
+    index0=$( echo "$last_liquidity0" | jq -r '.center_tick_index' )
+    reserves0=$( echo "$last_liquidity0" | jq -r '.shares_owned' )
 
     last_liquidity1=$( echo "$sorted_user_deposits" | jq '.[-1]' )
     fee1=$( echo "$last_liquidity1" | jq -r '.fee' )
-    index1=$( echo "$last_liquidity1" | jq -r '.centerTickIndex' )
-    reserves1=$( echo "$last_liquidity1" | jq -r '.sharesOwned' )
+    index1=$( echo "$last_liquidity1" | jq -r '.center_tick_index' )
+    reserves1=$( echo "$last_liquidity1" | jq -r '.shares_owned' )
 
     # withdraw the end values
     if [ ! -z $reserves0 ] && [ ! -z $reserves1 ]

--- a/scripts/run_trade_bot.sh
+++ b/scripts/run_trade_bot.sh
@@ -129,7 +129,9 @@ max_epoch_reached=false
 while true
 do
   # wait a bit, maybe less than a block or enough that we don't touch a block or two
-  sleep $(( $TRADE_FREQUENCY_SECONDS > 0 ? $RANDOM % $TRADE_FREQUENCY_SECONDS : 0 ))
+  DELAY=$(( $TRADE_FREQUENCY_SECONDS > 0 ? $RANDOM % $TRADE_FREQUENCY_SECONDS : 0 ))
+  echo ".. will delay for: $DELAY"
+  sleep $DELAY
 
   if [ ! -z $max_epoch ] && [ $max_epoch -lt $EPOCHSECONDS ]
   then
@@ -143,6 +145,8 @@ do
     pair_index+=1
     token0=$( echo $token_pair | jq -r .[0] )
     token1=$( echo $token_pair | jq -r .[1] )
+
+    echo "calculating: a swap on the pair '$token0' and '$token1'..."
 
     # create random fee tier to use in this iteration
     fee=${fee_options[$(( $RANDOM % 4 ))]}

--- a/scripts/run_trade_bot.sh
+++ b/scripts/run_trade_bot.sh
@@ -121,7 +121,7 @@ amplitude2=-2000 # in seconds
 period2=300 # in seconds
 two_pi=$( echo "scale=8; 8*a(1)" | bc -l )
 
-trade_frequency="${TRADE_FREQUENCY_SECONDS:-60}"
+TRADE_FREQUENCY_SECONDS="${TRADE_FREQUENCY_SECONDS:-60}"
 max_epoch=$( [ ! -z $TRADE_DURATION_SECONDS ] && echo $(( $EPOCHSECONDS + $TRADE_DURATION_SECONDS )) || echo "" )
 max_epoch_reached=false
 
@@ -129,7 +129,7 @@ max_epoch_reached=false
 while true
 do
   # wait a bit, maybe less than a block or enough that we don't touch a block or two
-  sleep $(( $RANDOM % $trade_frequency ))
+  sleep $(( $TRADE_FREQUENCY_SECONDS > 0 ? $RANDOM % $TRADE_FREQUENCY_SECONDS : 0 ))
 
   if [ ! -z $max_epoch ] && [ $max_epoch -lt $EPOCHSECONDS ]
   then

--- a/scripts/run_trade_bot.sh
+++ b/scripts/run_trade_bot.sh
@@ -10,7 +10,7 @@ neutrond() {
 # set which node we will talk to
 CHAIN_ID="${CHAIN_ID:-$(neutrond config chain-id)}"
 RPC_ADDRESS="${RPC_ADDRESS:-$(neutrond config node)}"
-GAS_ADJUSTMENT="${GAS_ADJUSTMENT:-"1.5"}"
+GAS_ADJUSTMENT="${GAS_ADJUSTMENT:-"2"}"
 GAS_PRICES="${GAS_PRICES:-"0.0025untrn"}"
 
 echo "CHAIN_ID: $CHAIN_ID"

--- a/scripts/run_trade_bot.sh
+++ b/scripts/run_trade_bot.sh
@@ -2,8 +2,9 @@
 set -e
 
 # alias neutrond to a specific Docker neutrond
+SCRIPTPATH="$( dirname "$(readlink "$BASH_SOURCE" || echo "$BASH_SOURCE")" )"
 neutrond() {
-  docker exec $NEUTROND_NODE neutrond "$@"
+  bash $SCRIPTPATH/helpers.sh neutrond "$@"
 }
 
 # set which node we will talk to
@@ -21,7 +22,6 @@ if [[ $? -ne 0 ]]; then
 fi
 
 # check that NODE and CHAIN_ID details are correct
-SCRIPTPATH="$( dirname "$(readlink "$BASH_SOURCE" || echo "$BASH_SOURCE")" )"
 bash $SCRIPTPATH/check_chain_status.sh $RPC_ADDRESS $CHAIN_ID
 
 # define the person to trade with as the "trader" account

--- a/scripts/run_trade_bot.sh
+++ b/scripts/run_trade_bot.sh
@@ -3,7 +3,7 @@ set -e
 
 # alias neutrond to a specific Docker neutrond
 neutrond() {
-  docker exec ${NEUTROND_NODE:-leader} neutrond "$@"
+  docker exec $NEUTROND_NODE neutrond "$@"
 }
 
 # set which node we will talk to
@@ -12,6 +12,13 @@ RPC_ADDRESS="${RPC_ADDRESS:-$(neutrond config node)}"
 
 echo "CHAIN_ID: $CHAIN_ID"
 echo "NODE: $RPC_ADDRESS"
+
+# check docker connection status for daemon commands
+echo "Docker proxy call test: neutrond version $( neutrond version )"
+if [[ $? -ne 0 ]]; then
+    echo "Cannot send neutrond commands to Neutron testnet"
+    exit 1
+fi
 
 # check that NODE and CHAIN_ID details are correct
 SCRIPTPATH="$( dirname "$(readlink "$BASH_SOURCE" || echo "$BASH_SOURCE")" )"

--- a/scripts/run_trade_bot.sh
+++ b/scripts/run_trade_bot.sh
@@ -10,6 +10,8 @@ neutrond() {
 # set which node we will talk to
 CHAIN_ID="${CHAIN_ID:-$(neutrond config chain-id)}"
 RPC_ADDRESS="${RPC_ADDRESS:-$(neutrond config node)}"
+GAS_ADJUSTMENT="${GAS_ADJUSTMENT:-"1.5"}"
+GAS_PRICES="${GAS_PRICES:-"0.0025untrn"}"
 
 echo "CHAIN_ID: $CHAIN_ID"
 echo "NODE: $RPC_ADDRESS"
@@ -103,7 +105,7 @@ do
     `# disable_autoswap` \
     "$(repeat_with_comma "false"),$(repeat_with_comma "false")" \
     `# options` \
-    --from $person --yes --output json --broadcast-mode sync --gas auto --gas-adjustment 1.5 \
+    --from $person --yes --output json --broadcast-mode sync --gas auto --gas-adjustment $GAS_ADJUSTMENT --gas-prices $GAS_PRICES \
     | jq -r '.txhash' \
     | xargs -I{} bash $SCRIPTPATH/helpers.sh waitForTxResult "$API_ADDRESS" "{}" \
     | jq -r '"[ tx code: \(.tx_response.code) ] [ tx hash: \(.tx_response.txhash) ]"' \
@@ -185,7 +187,7 @@ do
         `# use IMMEDIATE_OR_CANCEL which will has less strict checks that FILL_OR_KILL` \
         IMMEDIATE_OR_CANCEL \
         `# options` \
-        --from $person --yes --output json --broadcast-mode sync --gas auto --gas-adjustment 1.5 \
+        --from $person --yes --output json --broadcast-mode sync --gas auto --gas-adjustment $GAS_ADJUSTMENT --gas-prices $GAS_PRICES \
         | jq -r '.txhash' \
         | xargs -I{} bash $SCRIPTPATH/helpers.sh waitForTxResult $API_ADDRESS "{}" \
         | jq -r '"[ tx code: \(.tx_response.code) ] [ tx hash: \(.tx_response.txhash) ]"' \
@@ -216,7 +218,7 @@ do
           `# use IMMEDIATE_OR_CANCEL which will has less strict checks that FILL_OR_KILL` \
           IMMEDIATE_OR_CANCEL \
           `# options` \
-          --from $person --yes --output json --broadcast-mode sync --gas auto --gas-adjustment 1.5 \
+          --from $person --yes --output json --broadcast-mode sync --gas auto --gas-adjustment $GAS_ADJUSTMENT --gas-prices $GAS_PRICES \
           | jq -r '.txhash' \
           | xargs -I{} bash $SCRIPTPATH/helpers.sh waitForTxResult $API_ADDRESS "{}" \
           | jq -r '"[ tx code: \(.tx_response.code) ] [ tx hash: \(.tx_response.txhash) ]"' \
@@ -251,7 +253,7 @@ do
       `# disable_autoswap` \
       false,false \
       `# options` \
-      --from $person --yes --output json --broadcast-mode sync --gas auto --gas-adjustment 1.5 \
+      --from $person --yes --output json --broadcast-mode sync --gas auto --gas-adjustment $GAS_ADJUSTMENT --gas-prices $GAS_PRICES \
       | jq -r '.txhash' \
       | xargs -I{} bash $SCRIPTPATH/helpers.sh waitForTxResult $API_ADDRESS "{}" \
       | jq -r '"[ tx code: \(.tx_response.code) ] [ tx hash: \(.tx_response.txhash) ]"' \
@@ -294,7 +296,7 @@ do
         `# list of fees` \
         "$fee0,$fee1" \
         `# options` \
-        --from $person --yes --output json --broadcast-mode sync --gas auto --gas-adjustment 1.5 \
+        --from $person --yes --output json --broadcast-mode sync --gas auto --gas-adjustment $GAS_ADJUSTMENT --gas-prices $GAS_PRICES \
         | jq -r '.txhash' \
         | xargs -I{} bash $SCRIPTPATH/helpers.sh waitForTxResult $API_ADDRESS "{}" \
         | jq -r '"[ tx code: \(.tx_response.code) ] [ tx hash: \(.tx_response.txhash) ]"' \


### PR DESCRIPTION
The original trading bot for the Duality Dex is from here: https://github.com/duality-labs/dualityd-docker-services/blob/main/scripts/start_simulating_trades.sh

It has been upgraded to run on a v2.0.0 Neutron chain using the local Cosmopark setup of the `neutron-integration-tests` repo: https://github.com/neutron-org/neutron-integration-tests/blob/main/setup/Makefile 

With an extended and modified Cosmopark setup, the new Dex Trading Bot can generate `deposit`, `swap`, and `withdraw` dex transactions on the local Neutron chain using:
- `make build-neutron`
then
- `make run-trade-bot`
- or with options like: `TRADE_FREQUENCY_SECONDS=0 make run-trade-bot` for more frequent transactions