### PR TITLE
feat: Add multiple bot usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,13 @@ All docker-compose env vars are able to be set in both `make start-trade-bot` an
 
 eg. `make start-trade-bot BOTS=30 BOT_RAMPING_DELAY=5 TRADE_FREQUENCY_SECONDS=0 TRADE_DURATION_SECONDS=450`
 will start a persistent chain that for the first ~10min (7min+ramping) will generate ~5000txs using 30 bots.
+
+# Troubleshooting
+
+The chain should be visible at http://localhost:26657 and REST at http://localhost:1317.
+
+If you cannot these addresses from within a different Docker service (such as a local indexer), try using:
+```
+RPC_API=http://host.docker.internal:26657
+REST_API=http://host.docker.internal:1317
+```

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ You can test a chain and bot(s) configuration and exit with cleanup in one step 
 - `make test-trade-bot`
 
 However the default settings are quite conservative, and won't product many txs.
-A larger test which should generate approximately ~500txs txs in ~10 minutes could be done with:
-- `make test-trade-bot TRADE_FREQUENCY_SECONDS=0 TRADE_DURATION_SECONDS=180`
+A larger test which should generate approximately ~1000-2000 txs in ~6 minutes with 30 bots could be done with:
+- `make test-trade-bot BOTS=30 BOT_RAMPING_DELAY=5 TRADE_FREQUENCY_SECONDS=0 TRADE_DURATION_SECONDS=180`
 
 This can be ideal for CI type testing of a service that depends on Dex transactions on a Neutron chain.
 But if you want the chain to persist after the trades are completed (with a finite `TRADE_DURATION_SECONDS`),
@@ -40,10 +40,12 @@ All docker-compose env vars are able to be set in both `make start-trade-bot` an
 - Trading bot variables:
     - `RPC_ADDRESS`: RPC address of chain
     - `API_ADDRESS`: API address of chain
+    - `BOTS`: number of trading bots to run
+    - `BOT_RAMPING_DELAY`: seconds between starting each bot
     - `TRADE_DURATION_SECONDS`: how long trades should occur for
     - `TRADE_FREQUENCY_SECONDS`: how many seconds to delay between trades on a bot
     - `GAS_ADJUSTMENT`: how much more than the base estimated gas price to pay for each tx
     - `GAS_PRICES`: calculate how many fees to pay from this fraction of gas
 
-eg. `make start-trade-bot TRADE_FREQUENCY_SECONDS=0 TRADE_DURATION_SECONDS=600`
-will start a persistent chain that for the first ~10min will generate ~500txs.
+eg. `make start-trade-bot BOTS=30 BOT_RAMPING_DELAY=5 TRADE_FREQUENCY_SECONDS=0 TRADE_DURATION_SECONDS=450`
+will start a persistent chain that for the first ~10min (7min+ramping) will generate ~5000txs using 30 bots.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,10 @@ services:
       context: .
     depends_on:
       - "neutron-node"
+    deploy:
+      replicas: ${BOTS:-1}
     environment:
+      - BOT_RAMPING_DELAY=${BOT_RAMPING_DELAY:-3} # seconds between starting each bot
       - CHAIN_ID=${CHAIN_ID:-test-1}
       - NEUTROND_NODE=neutron-node
       - RPC_ADDRESS=${RPC_ADDRESS:-http://neutron-node:26657}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,9 @@ services:
         bash /opt/neutron/network/init.sh
         bash /opt/neutron/network/init-neutrond.sh
 
+        # set default keyring configuration to local test keys
+        neutrond --home "./data/$$CHAINID" config keyring-backend test
+
         # run chain
         echo "Starting $$CHAINID..."
         neutrond start                             \

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -23,7 +23,9 @@ createAndFundUser() {
             $tokens \
             --broadcast-mode sync \
             --output json \
-            --fees 500untrn \
+            --gas auto \
+            --gas-adjustment $GAS_ADJUSTMENT \
+            --gas-prices $GAS_PRICES \
             --yes \
     )
     if [ "$( echo $response | jq -r '.code' )" -eq "0" ]

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -11,7 +11,7 @@ createAndFundUser() {
     # create person name
     person=$(openssl rand -hex 12)
     # stagger the creationi of wallets on chain to avoid race conditions and "out of sequence" issues here:
-    BOT_RAMPING_DELAY="${BOT_RAMPING_DELAY:-3}"
+    BOT_RAMPING_DELAY="${BOT_RAMPING_DELAY:-5}"
     # enforce a minimum delay, a safe delay is at least one block space in seconds (which may be hard to predict)
     # a 6 second delay was needed to run more than 40 bots reliably
     BOT_RAMPING_DELAY=$(( $BOT_RAMPING_DELAY > 3 ? $BOT_RAMPING_DELAY : 3 ))

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -10,9 +10,10 @@ createAndFundUser() {
     tokens=$1
     # create person name
     person=$(openssl rand -hex 12)
+    echo "funding new user: $person with tokens $tokens" > /dev/stderr
     # create person's new account (with a random name and set passphrase)
     # the --no-backup flag only prevents output of the new key to the terminal
-    neutrond keys add $person --no-backup <<< $'asdfasdf\nn' >/dev/null
+    neutrond keys add $person --no-backup > /dev/stderr
     # send funds from frugal faucet friend (one of 3 denomwallet accounts)
     faucet="demowallet$(( $RANDOM % 3 + 1 ))"
     tx_hash=$(
@@ -22,11 +23,14 @@ createAndFundUser() {
             $tokens \
             --broadcast-mode sync \
             --output json \
+            --fees 500untrn \
             --yes \
             | jq -r '.txhash'
     )
     # get tx result for msg
-    tx_result=$(bash ./scripts/test_helpers.sh waitForTxResult "$API_ADDRESS" "$tx_hash")
+    tx_result=$(waitForTxResult "$API_ADDRESS" "$tx_hash")
+
+    echo "funded new user: $person with tokens $tokens" > /dev/stderr
 
     # return only person name for test usage
     echo "$person"

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -10,6 +10,13 @@ createAndFundUser() {
     tokens=$1
     # create person name
     person=$(openssl rand -hex 12)
+    # stagger the creationi of wallets on chain to avoid race conditions and "out of sequence" issues here:
+    BOT_RAMPING_DELAY="${BOT_RAMPING_DELAY:-3}"
+    # enforce a minimum delay, a safe delay is at least one block space in seconds (which may be hard to predict)
+    # a 6 second delay was needed to run more than 40 bots reliably
+    BOT_RAMPING_DELAY=$(( $BOT_RAMPING_DELAY > 3 ? $BOT_RAMPING_DELAY : 3 ))
+    docker_service_number=$( curl -s --unix-socket /run/docker.sock http://docker/containers/$HOSTNAME/json | jq -r '.Name | split("-") | last' )
+    sleep $(( $docker_service_number > 0 ? ($docker_service_number -1) * $BOT_RAMPING_DELAY : 0 ))
     echo "funding new user: $person with tokens $tokens" > /dev/stderr
     # create person's new account (with a random name and set passphrase)
     # the --no-backup flag only prevents output of the new key to the terminal

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -13,11 +13,12 @@ createAndFundUser() {
     # create person's new account (with a random name and set passphrase)
     # the --no-backup flag only prevents output of the new key to the terminal
     neutrond keys add $person --no-backup <<< $'asdfasdf\nn' >/dev/null
-    # send funds from frugal faucet friend (Fred)
+    # send funds from frugal faucet friend (one of 3 denomwallet accounts)
+    faucet="demowallet$(( $RANDOM % 3 + 1 ))"
     tx_hash=$(
         neutrond tx bank send \
-            $( neutrond keys show fred --output json | jq -r .address ) \
-            $( neutrond keys show $person --output json | jq -r .address ) \
+            $( neutrond keys show $faucet -a ) \
+            $( neutrond keys show $person -a ) \
             $tokens \
             --broadcast-mode sync \
             --output json \

--- a/scripts/run_trade_bot.sh
+++ b/scripts/run_trade_bot.sh
@@ -29,7 +29,9 @@ neutrond config keyring-backend test
 bash $SCRIPTPATH/check_chain_status.sh $RPC_ADDRESS $CHAIN_ID
 
 # define the person to trade with as the "trader" account
-person="demowallet1"
+tokens=100000000000
+person=$( bash $SCRIPTPATH/helpers.sh createAndFundUser "${tokens}untrn,${tokens}uibcatom,${tokens}uibcusdc" )
+address=$( neutrond keys show "$person" -a )
 
 # add some helper functions to generate chain CLI args
 count=100; # should be divisible by 4
@@ -89,7 +91,7 @@ do
   # apply an amount to all tick indexes specified
   neutrond tx dex deposit \
     `# receiver` \
-    "$(neutrond keys show "$person" --output json | jq -r .address)" \
+    $address \
     `# token-a` \
     $token0 \
     `# token-b` \
@@ -179,7 +181,7 @@ do
       response="$(
         neutrond tx dex place-limit-order \
         `# receiver` \
-        "$(neutrond keys show "$person" --output json | jq -r .address)" \
+        $address \
         `# token in` \
         $token1 \
         `# token out` \
@@ -219,7 +221,7 @@ do
         response="$(
           neutrond tx dex place-limit-order \
           `# receiver` \
-          "$(neutrond keys show "$person" --output json | jq -r .address)" \
+          $address \
           `# token in` \
           $token0 \
           `# token out` \
@@ -259,7 +261,7 @@ do
     echo "making deposit: '$token0' + '$token1'"
     neutrond tx dex deposit \
       `# receiver` \
-      "$(neutrond keys show "$person" --output json | jq -r .address)" \
+      $address \
       `# token-a` \
       $token0 \
       `# token-b` \
@@ -306,7 +308,7 @@ do
       echo "making withdrawal: '$token0' + '$token1'"
       neutrond tx dex withdrawal \
         `# receiver` \
-        "$(neutrond keys show "$person" --output json | jq -r .address)" \
+        $address \
         `# token-a` \
         $token0 \
         `# token-b` \

--- a/scripts/run_trade_bot.sh
+++ b/scripts/run_trade_bot.sh
@@ -10,8 +10,6 @@ neutrond() {
 # set which node we will talk to
 CHAIN_ID="${CHAIN_ID:-$(neutrond config chain-id)}"
 RPC_ADDRESS="${RPC_ADDRESS:-$(neutrond config node)}"
-GAS_ADJUSTMENT="${GAS_ADJUSTMENT:-"2"}"
-GAS_PRICES="${GAS_PRICES:-"0.0025untrn"}"
 
 echo "CHAIN_ID: $CHAIN_ID"
 echo "NODE: $RPC_ADDRESS"

--- a/scripts/run_trade_bot.sh
+++ b/scripts/run_trade_bot.sh
@@ -22,8 +22,6 @@ if [[ $? -ne 0 ]]; then
     echo "Cannot send neutrond commands to Neutron testnet"
     exit 1
 fi
-# set daemon calls to read test keys
-neutrond config keyring-backend test
 
 # check that NODE and CHAIN_ID details are correct
 bash $SCRIPTPATH/check_chain_status.sh $RPC_ADDRESS $CHAIN_ID

--- a/scripts/run_trade_bot.sh
+++ b/scripts/run_trade_bot.sh
@@ -65,7 +65,7 @@ indexes1=()
 amounts0=()
 amounts1=()
 fees=()
-amount=1000000000 # use a base billion tokens, assume coins have 6 decimal places
+amount=$(( $tokens / 1000 )) # use 0.1% of budget in each pool (will make $count/4 pools)
 for (( i=0; i<$count/4; i++ ))
 do
   index=$(( $RANDOM % $max_tick_index ))


### PR DESCRIPTION
should merge #1 first.

This PR updates the local docker compose network to be able to handle multiple trading bots are the same time. 

My MacBook Pro M1Max was able to handle 50 bots with 0 seconds delays:
- `make test-trade-bot TRADE_FREQUENCY_SECONDS=0 BOTS=50 BOT_RAMPING_DELAY=6`
  - ran the network at about a 10tx/s speed
- `make test-trade-bot TRADE_FREQUENCY_SECONDS=0 BOTS=30 BOT_RAMPING_DELAY=5`
  - ran the network at about a 15tx/s speed
