### PR TITLE
feat: Improve ramping time accuracy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ FROM "$NEUTRON_IMAGE" as neutrond-binary
 FROM docker:24.0.5-cli
 
 # add additional dependencies for the testnet scripts
-RUN apk add bash curl grep openssl jq;
+RUN apk add bash curl grep jq;
 
 COPY --from=neutrond-binary /bin/neutrond /usr/bin
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,14 @@
+# get base image of neutrond binary to use in trade script
+FROM neutron-node as neutrond-binary
+
+
 # allow this container to contact other Docker containers through the docker CLI
 FROM docker:24.0.5-cli
 
 # add additional dependencies for the testnet scripts
 RUN apk add bash curl grep openssl jq;
+
+COPY --from=neutrond-binary /go/bin/neutrond /usr/bin
 
 WORKDIR /workspace/neutron
 COPY scripts /workspace/neutron/scripts

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,11 @@
-# get base image of neutrond binary to use in trade script
-FROM neutron-node as neutrond-binary
+# Use neutron binary version given through version number or heighliner image
+# eg. passing a locally made heighliner image as NEUTRON_IMAGE
+ARG NEUTRON_VERSION
+# Use Heighliner build by default to get around building for correct platform issue
+# as Heighliner build support multiple platforms. More details in commit message
+ARG NEUTRON_IMAGE=ghcr.io/strangelove-ventures/heighliner/neutron:${NEUTRON_VERSION}
 
+FROM "$NEUTRON_IMAGE" as neutrond-binary
 
 # allow this container to contact other Docker containers through the docker CLI
 FROM docker:24.0.5-cli
@@ -8,7 +13,7 @@ FROM docker:24.0.5-cli
 # add additional dependencies for the testnet scripts
 RUN apk add bash curl grep openssl jq;
 
-COPY --from=neutrond-binary /go/bin/neutrond /usr/bin
+COPY --from=neutrond-binary /bin/neutrond /usr/bin
 
 WORKDIR /workspace/neutron
 COPY scripts /workspace/neutron/scripts

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ clean:
 # --- new docker compose network commands ---
 
 build-trade-bot:
-	@$(COMPOSE) build
+	@$(COMPOSE) build --build-arg NEUTRON_VERSION=$(NEUTRON_VERSION)
 
 start-trade-bot: build-trade-bot
 	@$(COMPOSE) up

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ All docker-compose env vars are able to be set in both `make start-trade-bot` an
     - `TRADE_FREQUENCY_SECONDS`: how many seconds to delay between trades on a bot
     - `GAS_ADJUSTMENT`: how much more than the base estimated gas price to pay for each tx
     - `GAS_PRICES`: calculate how many fees to pay from this fraction of gas
+    - `MNEMONICS`: the mnemonics for the account(s) that tokens will be used from (required)
+        - with a local chain you can use `DEMO_MNEMONIC`s from the neutron networks/init.sh file
 
 eg. `make start-trade-bot BOTS=30 BOT_RAMPING_DELAY=5 TRADE_FREQUENCY_SECONDS=0 TRADE_DURATION_SECONDS=450`
 will start a persistent chain that for the first ~10min (7min+ramping) will generate ~5000txs using 30 bots.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,7 +53,6 @@ services:
     deploy:
       replicas: ${BOTS:-1}
     environment:
-      - BOTS=${BOTS:-1}
       - BOT_RAMPING_DELAY=${BOT_RAMPING_DELAY:-3} # seconds between starting each bot
       - CHAIN_ID=${CHAIN_ID:-test-1}
       - NEUTROND_NODE=neutron-node

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,6 +62,8 @@ services:
       - TRADE_FREQUENCY_SECONDS=${TRADE_FREQUENCY_SECONDS:-60}
       - GAS_ADJUSTMENT=${GAS_ADJUSTMENT:-2}
       - GAS_PRICES=${GAS_PRICES:-0.0025untrn}
+      - MNEMONICS=${MNEMONICS}
+      - MNEMONIC=${MNEMONIC}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,8 +60,9 @@ services:
       - TRADE_FREQUENCY_SECONDS=${TRADE_FREQUENCY_SECONDS:-60}
       - GAS_ADJUSTMENT=${GAS_ADJUSTMENT:-2}
       - GAS_PRICES=${GAS_PRICES:-0.0025untrn}
-      - MNEMONICS=${MNEMONICS}
-      - MNEMONIC=${MNEMONIC}
+      # faucet mnemonics should be set with specific MNEMONIC/S:
+      # mnemonics may be delimited with: line breaks, tabs, semicolons, commas, and multiple spaces
+      - MNEMONICS=${MNEMONICS:-$MNEMONIC}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,6 +53,7 @@ services:
     deploy:
       replicas: ${BOTS:-1}
     environment:
+      - BOTS=${BOTS:-1}
       - BOT_RAMPING_DELAY=${BOT_RAMPING_DELAY:-3} # seconds between starting each bot
       - CHAIN_ID=${CHAIN_ID:-test-1}
       - NEUTROND_NODE=neutron-node

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,8 @@ services:
       context: .
     depends_on:
       - "neutron-node"
+    entrypoint: ["/bin/bash", "./scripts/setup_entrypoint.sh"]
+    command: ["/bin/bash", "./scripts/run_trade_bot.sh"]
     deploy:
       replicas: ${BOTS:-1}
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,9 +16,6 @@ services:
         CHAIN_DIR="$$BASE_DIR/$$CHAINID"
         sed -i -e "s/cors_allowed_origins = \[\]/cors_allowed_origins = $$CORS_ALLOWED_ORIGINS/g" "$$CHAIN_DIR/config/config.toml"
 
-        # set default keyring configuration to local test keys
-        neutrond --home "$$CHAIN_DIR" config keyring-backend test
-
         # run chain
         echo "Starting $$CHAINID..."
         neutrond start                             \
@@ -55,7 +52,6 @@ services:
     environment:
       - BOT_RAMPING_DELAY=${BOT_RAMPING_DELAY:-3} # seconds between starting each bot
       - CHAIN_ID=${CHAIN_ID:-test-1}
-      - NEUTROND_NODE=neutron-node
       - RPC_ADDRESS=${RPC_ADDRESS:-http://neutron-node:26657}
       - API_ADDRESS=${API_ADDRESS:-http://neutron-node:1317}
       - TRADE_DURATION_SECONDS=${TRADE_DURATION_SECONDS:-}

--- a/scripts/check_chain_status.sh
+++ b/scripts/check_chain_status.sh
@@ -13,8 +13,8 @@ neutrond config keyring-backend test
 echo "CHAIN_ID: $CHAIN_ID"
 echo "NODE: $RPC_ADDRESS"
 
-# check docker connection status for daemon commands
-echo "Docker proxy call test: neutrond version $( neutrond version )"
+# check binary version status for daemon commands
+echo "neutrond version: $( neutrond version )"
 if [[ $? -ne 0 ]]; then
     echo "Cannot send neutrond commands to Neutron testnet"
     exit 1

--- a/scripts/check_chain_status.sh
+++ b/scripts/check_chain_status.sh
@@ -1,8 +1,24 @@
 #!/bin/bash
 set -e
 
-RPC_ADDRESS=$1
-CHAIN_ID=$2
+CHAIN_ID="${CHAIN_ID:-neutron}"
+RPC_ADDRESS="${RPC_ADDRESS}"
+
+# setup neutrond config in default config folder
+mkdir -p /root/.neutrond
+neutrond config chain-id $CHAIN_ID
+neutrond config node $RPC_ADDRESS
+neutrond config keyring-backend test
+
+echo "CHAIN_ID: $CHAIN_ID"
+echo "NODE: $RPC_ADDRESS"
+
+# check docker connection status for daemon commands
+echo "Docker proxy call test: neutrond version $( neutrond version )"
+if [[ $? -ne 0 ]]; then
+    echo "Cannot send neutrond commands to Neutron testnet"
+    exit 1
+fi
 
 echo "Connecting to testnet: $RPC_ADDRESS ..."
 # check if we can get information from the testnet

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -1,11 +1,6 @@
 #!/bin/bash
 set -e
 
-# alias neutrond to a specific Docker neutrond
-neutrond() {
-    docker exec $NEUTROND_NODE neutrond --home /opt/neutron/data/$CHAIN_ID "$@"
-}
-
 getDockerEnv() {
     # get this Docker container env info
     curl -s --unix-socket /run/docker.sock http://docker/containers/$HOSTNAME/json
@@ -128,7 +123,8 @@ getFaucetWallet() {
         echo "$mnemonic" | neutrond keys add $person --recover > /dev/null
         echo "$person";
     else
-        echo "demowallet$(( ($bot_number - 1) % 3 + 1 ))"
+        echo "at least one mnemonic should be provided in MNEMONIC/MNEMONICS"
+        exit 1
     fi
 }
 
@@ -147,7 +143,7 @@ createAndFundUser() {
     # create person's new account (with a random name and set passphrase)
     # the --no-backup flag only prevents output of the new key to the terminal
     neutrond keys add $person --no-backup > /dev/stderr
-    # send funds from frugal faucet friend (from MNEMONICS or demowallet)
+    # send funds from frugal faucet friend (from MNEMONICS)
     faucet="$( getFaucetWallet )"
     response=$(
         neutrond tx bank send \

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -17,6 +17,20 @@ getBotNumber() {
     fi
 }
 
+getBotStartTime() {
+    bot_number=${1:-"$( getBotNumber )"}
+    echo "$(( ($bot_number - 1) * $BOT_RAMPING_DELAY + $EPOCHSECONDS ))"
+}
+getBotEndTime() {
+    bot_number=${1:-"$( getBotNumber )"}
+    TRADE_DURATION_SECONDS="${TRADE_DURATION_SECONDS:-0}"
+    if [ $TRADE_DURATION_SECONDS -gt 0 ]
+    then
+        start_time=$( getBotStartTime $bot_number )
+        echo "$(( $start_time + $TRADE_DURATION_SECONDS ))"
+    fi
+}
+
 createAndFundUser() {
     tokens=$1
     # create person name

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -31,7 +31,8 @@ getBotStartTime() {
     # get global start time from the creation of the first bot
     global_start_time="$( echo "$( getDockerEnvs )" | jq -r '.[0].Created' )"
     global_start_epoch="$( date -u -d "$global_start_time" -D '%Y-%m-%dT%H:%M:%S' +'%s' )"
-    echo "$(( ($bot_number - 1) * $BOT_RAMPING_DELAY + $global_start_epoch ))"
+    start_up_time="15"
+    echo "$(( ($bot_number - 1) * $BOT_RAMPING_DELAY + $global_start_epoch + $start_up_time ))"
 }
 getBotEndTime() {
     bot_number=${1:-"$( getBotNumber )"}

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -105,7 +105,7 @@ createMnemonic() {
     docker_env="${1:-"$( getDockerEnv )"}"
     # create mnenomic from container Env (without line breaks)
     neutrond keys mnemonic --keyring-backend test --unsafe-entropy <<EOF
-"$( echo "$docker_env" | jq '.Config' | xargs echo -n )"
+"$( echo "$docker_env" | jq '.Config' | tr -d '\r' | tr '\n' ' ' )"
 y
 EOF
 }
@@ -129,7 +129,7 @@ getFaucetWallet() {
     MNEMONICS="${MNEMONICS:-"$MNEMONIC"};"
     mnemonics_array=()
     i=1
-    while mnemonic=$(echo "$MNEMONICS" | cut -d\; -f$i | xargs echo -n); [ -n "$mnemonic" ]
+    while mnemonic=$(echo "$MNEMONICS" | cut -d\; -f$i ); [ -n "$mnemonic" ]
     do
         mnemonics_array+=( "$mnemonic" )
         i=$(( i+1 ))

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -138,12 +138,13 @@ getFaucetWallet() {
         fi
         i=$(( i+1 ))
     done
-    if [ "${#mnemonics_array[@]}" -gt 0 ]
+
+    # pick the mnenomic to use out of the valid array
+    bot_number="$( getBotNumber "$docker_env" )"
+    bot_index=$(( ($bot_number - 1) % ${#mnemonics_array[@]} ))
+    mnemonic=$(echo "${mnemonics_array[$bot_index]}")
+    if [ ! -z "$mnemonic" ]
     then
-        # pick the mnenomic to use out of the valid array
-        bot_number="$( getBotNumber )"
-        bot_index=$(( ($bot_number - 1) % ${#mnemonics_array[@]} ))
-        mnemonic=$(echo "${mnemonics_array[$bot_index]}")
         # add the faucet account
         person="faucet"
         echo "$mnemonic" | neutrond keys add $person --recover > /dev/null

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -9,7 +9,7 @@ neutrond() {
 getBotNumber() {
     docker_service_number=$(
         curl -s --unix-socket /run/docker.sock http://docker/containers/$HOSTNAME/json \
-        | jq -r '.Name | split("-") | last'
+        | jq -r '.Config.Labels["com.docker.compose.container-number"]'
     )
     if [ "$docker_service_number" -gt "0" ]
     then

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -44,7 +44,7 @@ createAndFundUser() {
             --gas auto \
             --gas-adjustment $GAS_ADJUSTMENT \
             --gas-prices $GAS_PRICES \
-            --yes \
+            --yes
     )
     if [ "$( echo $response | jq -r '.code' )" -eq "0" ]
     then

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -131,7 +131,11 @@ getFaucetWallet() {
     i=1
     while mnemonic=$(echo "$MNEMONICS" | cut -d\; -f$i ); [ -n "$mnemonic" ]
     do
-        mnemonics_array+=( "$mnemonic" )
+        # do not include duplicates
+        if [[ ! " ${mnemonics_array} " =~ " ${mnemonic} " ]]
+        then
+            mnemonics_array+=( "$mnemonic" )
+        fi
         i=$(( i+1 ))
     done
     if [ "${#mnemonics_array[@]}" -gt 0 ]

--- a/scripts/run_trade_bot.sh
+++ b/scripts/run_trade_bot.sh
@@ -361,7 +361,7 @@ done
 
 echo "TRADE_DURATION_SECONDS has been reached";
 
-# wait for all bots to finish before exiting
-bash $SCRIPTPATH/helpers.sh waitForOtherBotsToEnd
+# wait for all bots to finish this stage before exiting
+bash $SCRIPTPATH/helpers.sh waitForAllBotsToSynchronizeToStage trading_finished 3
 
 echo "exiting trade script"

--- a/scripts/run_trade_bot.sh
+++ b/scripts/run_trade_bot.sh
@@ -60,6 +60,7 @@ token_pairs=( '["uibcusdc","untrn"]' '["uibcatom","uibcusdc"]' '["uibcatom","unt
 # create initial tick array outside of max price amplitude
 fee_options=( 1 5 20 100 )
 max_tick_index=12000
+indexes=()
 indexes0=()
 indexes1=()
 amounts0=()
@@ -69,6 +70,12 @@ amount=$(( $tokens / 1000 )) # use 0.1% of budget in each pool (will make $count
 for (( i=0; i<$count/4; i++ ))
 do
   index=$(( $RANDOM % $max_tick_index ))
+  # pick another index if this one was already used
+  while [[ " ${indexes[*]} " =~ " ${index} " ]]
+  do
+      index=$(( $RANDOM % $max_tick_index ))
+  done
+  indexes+=( $index )
   indexes0+=( $(( -$max_tick_index - $index )) -$index )
   indexes1+=( $index $(( $index + $max_tick_index )) )
   # calculate reserve amounts to add that will equal the same amount of shares

--- a/scripts/run_trade_bot.sh
+++ b/scripts/run_trade_bot.sh
@@ -128,7 +128,6 @@ two_pi=$( echo "scale=8; 8*a(1)" | bc -l )
 
 TRADE_FREQUENCY_SECONDS="${TRADE_FREQUENCY_SECONDS:-60}"
 max_epoch=$( [ ! -z $TRADE_DURATION_SECONDS ] && echo $(( $EPOCHSECONDS + $TRADE_DURATION_SECONDS )) || echo "" )
-max_epoch_reached=false
 
 # respond to price changes forever
 while true

--- a/scripts/run_trade_bot.sh
+++ b/scripts/run_trade_bot.sh
@@ -370,10 +370,11 @@ echo "TRADE_DURATION_SECONDS has been reached";
 if [ "$BOTS" -gt "1" ]
 then
   # wait approximate time for other bots to finish
-  echo "waiting for other bots to finish"
   bot_total="$BOTS"
   end_epoch=$( bash $SCRIPTPATH/helpers.sh getBotEndTime $bot_total )
-  sleep $(( $EPOCHSECONDS - $end_epoch ))
+  delay=$(( $end_epoch - $EPOCHSECONDS > 0 ? $end_epoch - $EPOCHSECONDS : 0 ))
+  echo "waiting for other bots to finish ($delay seconds)"
+  sleep "$delay"
 
   # add ~2 block heights of time tolerance for randomness in trades amongst bots
   sleep 10;

--- a/scripts/run_trade_bot.sh
+++ b/scripts/run_trade_bot.sh
@@ -361,23 +361,7 @@ done
 
 echo "TRADE_DURATION_SECONDS has been reached";
 
-# if this is a fleet of bots, only allow the last bot to finish the service
-# note: this assumes that any previous runs of the network was correctly closed
-#       eg. using `make stop-trade-bot` or `make test-trade-bot`
-#       if the network was not brought down correctly the service ID numbers
-#       may not match the number of BOTS set
-
-if [ "$BOTS" -gt "1" ]
-then
-  # wait approximate time for other bots to finish
-  bot_total="$BOTS"
-  end_epoch=$( bash $SCRIPTPATH/helpers.sh getBotEndTime $bot_total )
-  delay=$(( $end_epoch - $EPOCHSECONDS > 0 ? $end_epoch - $EPOCHSECONDS : 0 ))
-  echo "waiting for other bots to finish ($delay seconds)"
-  sleep "$delay"
-
-  # add ~2 block heights of time tolerance for randomness in trades amongst bots
-  sleep 10;
-fi
+# wait for all bots to finish before exiting
+bash $SCRIPTPATH/helpers.sh waitForOtherBotsToEnd
 
 echo "exiting trade script"

--- a/scripts/run_trade_bot.sh
+++ b/scripts/run_trade_bot.sh
@@ -27,7 +27,7 @@ bash $SCRIPTPATH/check_chain_status.sh $RPC_ADDRESS $CHAIN_ID
 
 # define the person to trade with as the "trader" account
 tokens=100000000000
-person=$( bash $SCRIPTPATH/helpers.sh createAndFundUser "${tokens}untrn,${tokens}uibcatom,${tokens}uibcusdc" )
+person=$( bash $SCRIPTPATH/helpers.sh fundUser "${tokens}untrn,${tokens}uibcatom,${tokens}uibcusdc" )
 address=$( neutrond keys show "$person" -a )
 
 # add some helper functions to generate chain CLI args

--- a/scripts/run_trade_bot.sh
+++ b/scripts/run_trade_bot.sh
@@ -4,30 +4,12 @@ set -e
 # make script path consistent
 SCRIPTPATH="$( dirname "$(readlink "$BASH_SOURCE" || echo "$BASH_SOURCE")" )"
 
-# setup neutrond config in default config folder
-mkdir /root/.neutrond
-CHAIN_ID="${CHAIN_ID:-neutron}"
-RPC_ADDRESS="${RPC_ADDRESS}"
-neutrond config chain-id $CHAIN_ID
-neutrond config node $RPC_ADDRESS
-neutrond config keyring-backend test
-
-echo "CHAIN_ID: $CHAIN_ID"
-echo "NODE: $RPC_ADDRESS"
-
-# check docker connection status for daemon commands
-echo "Docker proxy call test: neutrond version $( neutrond version )"
-if [[ $? -ne 0 ]]; then
-    echo "Cannot send neutrond commands to Neutron testnet"
-    exit 1
-fi
-
-# check that NODE and CHAIN_ID details are correct
-bash $SCRIPTPATH/check_chain_status.sh $RPC_ADDRESS $CHAIN_ID
+# wait for chain to be ready
+bash $SCRIPTPATH/check_chain_status.sh
 
 # define the person to trade with as the "trader" account
 tokens=100000000000
-person=$( bash $SCRIPTPATH/helpers.sh fundUser "${tokens}untrn,${tokens}uibcatom,${tokens}uibcusdc" )
+person=$( bash $SCRIPTPATH/helpers.sh getFundedUser )
 address=$( neutrond keys show "$person" -a )
 
 # add some helper functions to generate chain CLI args

--- a/scripts/run_trade_bot.sh
+++ b/scripts/run_trade_bot.sh
@@ -1,15 +1,16 @@
 #!/bin/bash
 set -e
 
-# alias neutrond to a specific Docker neutrond
+# make script path consistent
 SCRIPTPATH="$( dirname "$(readlink "$BASH_SOURCE" || echo "$BASH_SOURCE")" )"
-neutrond() {
-  bash $SCRIPTPATH/helpers.sh neutrond "$@"
-}
 
-# set which node we will talk to
-CHAIN_ID="${CHAIN_ID:-$(neutrond config chain-id)}"
-RPC_ADDRESS="${RPC_ADDRESS:-$(neutrond config node)}"
+# setup neutrond config in default config folder
+mkdir /root/.neutrond
+CHAIN_ID="${CHAIN_ID:-neutron}"
+RPC_ADDRESS="${RPC_ADDRESS}"
+neutrond config chain-id $CHAIN_ID
+neutrond config node $RPC_ADDRESS
+neutrond config keyring-backend test
 
 echo "CHAIN_ID: $CHAIN_ID"
 echo "NODE: $RPC_ADDRESS"

--- a/scripts/setup_entrypoint.sh
+++ b/scripts/setup_entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Trap SIGTERM
+trap 'true' SIGTERM
+
+# Setup env
+bash scripts/setup_fund_users.sh
+
+# Execute command
+"${@}" &
+
+# Wait
+wait $!
+
+# Cleanup
+bash scripts/setup_refund_users.sh

--- a/scripts/setup_entrypoint.sh
+++ b/scripts/setup_entrypoint.sh
@@ -5,12 +5,25 @@ trap 'true' SIGTERM
 
 # Setup env
 bash scripts/setup_fund_users.sh
+setup_error_code="$?"
 
-# Execute command
-"${@}" &
+# if setup completed fine then do command
+if [ "$setup_error_code" -eq "0" ]
+then
+    # Execute command
+    "${@}" &
 
-# Wait
-wait $!
+    # Wait
+    wait $!
+    command_error_code="$?"
+
+else
+    # let user know they probably had a JSON parse error
+    echo "setup failed (error code: $setup_error_code)"
+fi
 
 # Cleanup
 bash scripts/setup_refund_users.sh
+
+# return either error code
+exit $(( ${command_error_code:-0} + $setup_error_code ))

--- a/scripts/setup_entrypoint.sh
+++ b/scripts/setup_entrypoint.sh
@@ -22,8 +22,7 @@ else
     echo "setup failed (error code: $setup_error_code)"
 fi
 
-# Cleanup
-bash scripts/setup_refund_users.sh
+# Cleanup: any cleanup steps can go here
 
 # return either error code
 exit $(( ${command_error_code:-0} + $setup_error_code ))

--- a/scripts/setup_fund_users.sh
+++ b/scripts/setup_fund_users.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+set -e
+
+SCRIPTPATH="$( dirname "$(readlink "$BASH_SOURCE" || echo "$BASH_SOURCE")" )"
+
+# wait for chain to be ready
+bash $SCRIPTPATH/check_chain_status.sh
+
+# define the amount of funds to use
+tokens=100000000000
+
+docker_env="$( bash $SCRIPTPATH/helpers.sh getDockerEnv )"
+bot_number="$( bash $SCRIPTPATH/helpers.sh getBotNumber "$docker_env" )"
+
+# fund all bots from bot 1
+if [ "$bot_number" -eq "1" ]
+then
+    # get funding user
+    funder=$( bash $SCRIPTPATH/helpers.sh getFaucetWallet "$docker_env" )
+
+    # gather the users of each bot container, one by one
+    docker_envs="$( bash $SCRIPTPATH/helpers.sh getDockerEnvs "$docker_env" )"
+    docker_envs_count="$( echo "$docker_envs" | jq -r 'length' )"
+    user_addresses_array=()
+    for (( i=0; i<$docker_envs_count; i++ ))
+    do
+        docker_env="$( echo "$docker_envs" | jq ".[$i]" )"
+
+        # get fundee user
+        user=$( bash $SCRIPTPATH/helpers.sh createUser "$docker_env"  )
+        user_addresses_array+=( "$( neutrond keys show $user -a )" )
+    done
+
+    # multi-send to multiple users ($tokens amount is sent to each user)
+    tokens="${tokens}untrn,${tokens}uibcatom,${tokens}uibcusdc"
+    response=$(
+        neutrond tx bank multi-send \
+            "$( neutrond keys show $funder -a )" \
+            "${user_addresses_array[@]}" \
+            $tokens \
+            --broadcast-mode sync \
+            --output json \
+            --gas auto \
+            --gas-adjustment $GAS_ADJUSTMENT \
+            --gas-prices $GAS_PRICES \
+            --yes
+    )
+    if [ "$( echo $response | jq -r '.code' )" -eq "0" ]
+    then
+        tx_hash=$( echo $response | jq -r '.txhash' )
+        # get tx result for msg
+        tx_result=$( bash $SCRIPTPATH/helpers.sh waitForTxResult "$API_ADDRESS" "$tx_hash" )
+
+        echo "funded users: ${user_addresses_array[@]} with tokens $tokens"
+    else
+        echo "funding user error (code: $( echo $response | jq -r '.code' )): $( echo $response | jq -r '.raw_log' )" > /dev/stderr
+    fi
+fi

--- a/scripts/setup_fund_users.sh
+++ b/scripts/setup_fund_users.sh
@@ -55,8 +55,12 @@ then
         tx_hash=$( echo $response | jq -r '.txhash' )
         # get tx result for msg
         tx_result=$( bash $SCRIPTPATH/helpers.sh waitForTxResult "$API_ADDRESS" "$tx_hash" )
-
-        echo "funded users: ${user_addresses_array[@]} with tokens $tokens"
+        if [ "$( echo "$tx_result" | jq -r '.tx_response.code' )" -eq "0" ]
+        then
+            echo "funded users: ${user_addresses_array[@]} with tokens $tokens"
+        else
+            echo "funding user error (code: $( echo $response | jq -r '.tx_response.code' )): $( echo $response | jq -r '.tx_response.raw_log' )" > /dev/stderr
+        fi
     else
         echo "funding user error (code: $( echo $response | jq -r '.code' )): $( echo $response | jq -r '.raw_log' )" > /dev/stderr
     fi

--- a/scripts/setup_fund_users.sh
+++ b/scripts/setup_fund_users.sh
@@ -33,8 +33,13 @@ then
 
     # multi-send to multiple users ($tokens amount is sent to each user)
     tokens="${tokens}untrn,${tokens}uibcatom,${tokens}uibcusdc"
+    send_or_multi_send="send"
+    if [ "${#user_addresses_array[@]}" -gt 1 ]
+    then
+        send_or_multi_send="multi-send"
+    fi
     response=$(
-        neutrond tx bank multi-send \
+        neutrond tx bank $send_or_multi_send \
             "$( neutrond keys show $funder -a )" \
             "${user_addresses_array[@]}" \
             $tokens \

--- a/scripts/setup_refund_users.sh
+++ b/scripts/setup_refund_users.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-set -e

--- a/scripts/setup_refund_users.sh
+++ b/scripts/setup_refund_users.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+set -e


### PR DESCRIPTION
This PR improves the ramp-up and ramp-down time synchronization when running multiple bots

It does this through:

## branch: `improve-ramping-time-accuracy`
see [diff](https://github.com/neutron-org/dex-trading-bot/compare/improve-multiple-bot-usage...improve-ramping-time-accuracy?expand=1)
- syncing start of simulation times through `docker inspect` calls
- calculating end of simulation times using synced start times
## branch: `improve-ramping-time-accuracy-part-2`
see [diff](https://github.com/neutron-org/dex-trading-bot/compare/improve-ramping-time-accuracy...improve-ramping-time-accuracy-part-2?expand=1)
- coordinating deposits to all bots before starting the trading simulation (so no `out of sequence` errors can occur)
    - this coordination requires deterministic creation of all new mnemonics
    - which is achieved by using `docker inspect` calls to use each bots environment as seed entropy
- using native `neutrond` binaries in each bot instead of calling the chain's binary through `docker exec` calls
    - the binary was sourced through the equivalent heighliner build because ARM-based cpus (like mine) will attempt to query `docker.io/library/neutron-node:latest` and fail to build, instead of using the locally available `neutron-node` image we have previously built (see: 544fdb70ed942bfe44042157cdf20d0962c1a8a8).
    - this may not have been necessary, but I was unable to use the deterministic key creation command through an exec call: ie. the command `neutrond keys mnemonic` requires interactive input, which I could only solve through providing a heredoc to a native binary. A greater person may have been able to put the interactive input through the `docker exec` call somehow...
    - `MNEMONIC/S` env var must now be used as we cannot simply reference the local chain `demowallet1` account