### PR TITLE
feat: Improve simulation to be less one sided

### DIFF
--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -50,6 +50,7 @@ getBotNumber() {
 #   "ticks":            100,            # number of ticks for each bot to deposit
 #   "fees":             [1, 5, 20, 100] # each LP deposit fee may be (randomly) one of the whitelisted fees here
 #   "gas":              "0untrn"        # additional gas tokens that bots can use to cover gas fees
+#   "deposit_factor":   0.1,            # fraction of the recommended maximum reserves to use on a single tick deposit
 #   "swap_factor":      0.1,            # max fraction of a bot's token reserves to use on a single swap trade (max: 1)
 #   "swap_accuracy":    100,            # ~1% of price:     swaps will target within ~1% of current price
 #   "deposit_accuracy": 1000,           # ~10% of price:    deposits will target within ~10% of current price
@@ -108,6 +109,7 @@ getTokenConfigArray() {
                 price: (.value.price // $defaults.price // 1),
                 ticks: (.value.ticks // $defaults.ticks // 100),
                 fees: (.value.fees // $defaults.fees // [1, 5, 20, 100]),
+                deposit_factor: (.value.deposit_factor // $defaults.deposit_factor // 0.1),
                 swap_factor: (.value.swap_factor // $defaults.swap_factor // 0.1),
                 swap_accuracy: (.value.swap_accuracy // $defaults.swap_accuracy // 100),
                 deposit_accuracy: (.value.deposit_accuracy // $defaults.deposit_accuracy // 1000),

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -214,10 +214,16 @@ getBotStartTime() {
     fi
 }
 getBotEndTime() {
-    bot_number=${1:-"$( getBotNumber )"}
+    minimum_duration=${1:-"0"}
+    bot_number=${2:-"$( getBotNumber )"}
     TRADE_DURATION_SECONDS="${TRADE_DURATION_SECONDS:-0}"
     if [ $TRADE_DURATION_SECONDS -gt 0 ]
     then
+        # make trade duration at least one trade long
+        if [ "$TRADE_DURATION_SECONDS" -lt "$minimum_duration" ]
+        then
+            TRADE_DURATION_SECONDS="$minimum_duration"
+        fi
         start_time=$( getBotStartTime $bot_number )
         echo "$(( $start_time + $TRADE_DURATION_SECONDS ))"
     fi

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -50,6 +50,7 @@ getBotNumber() {
 #   "ticks":            100,            # number of ticks for each bot to deposit
 #   "fees":             [1, 5, 20, 100] # each LP deposit fee may be (randomly) one of the whitelisted fees here
 #   "gas":              "0untrn"        # additional gas tokens that bots can use to cover gas fees
+#   "swap_factor":      0.1,            # max fraction of a bot's token reserves to use on a single swap trade (max: 1)
 #   "swap_accuracy":    100,            # ~1% of price:     swaps will target within ~1% of current price
 #   "deposit_accuracy": 1000,           # ~10% of price:    deposits will target within ~10% of current price
 #   "amplitude1":       5000,           # ~50% of price:    current price will vary by ~50% of set price ratio
@@ -107,6 +108,7 @@ getTokenConfigArray() {
                 price: (.value.price // $defaults.price // 1),
                 ticks: (.value.ticks // $defaults.ticks // 100),
                 fees: (.value.fees // $defaults.fees // [1, 5, 20, 100]),
+                swap_factor: (.value.swap_factor // $defaults.swap_factor // 0.1),
                 swap_accuracy: (.value.swap_accuracy // $defaults.swap_accuracy // 100),
                 deposit_accuracy: (.value.deposit_accuracy // $defaults.deposit_accuracy // 1000),
                 amplitude1: (.value.amplitude1 // $defaults.amplitude1 // 5000),

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -478,7 +478,7 @@ waitForTxResult() {
     # log end
     # add standard parts
     log+=$'\n'
-    log+="$( echo "$tx_response" | jq -r '"- [ tx code: \(.code) ] [ tx hash: \(.txhash // .tx_hash // "unknown hash") ]"' )"
+    log+="$( echo "$tx_response" | jq -r '"- [ tx code: \(.code) ] [ tx hash: \(.txhash // .tx_hash) ]"' )"
     if [ "$code" -ne "0" ]
     then
         log+=' '

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -446,7 +446,7 @@ throwOnTxError() {
 }
 
 waitForTxResult() {
-    tx_response="$1"
+    tx_response="${1:-"{}"}"
     on_success_log="$2"
     on_error_log="$3"
     # check that the request was a success

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -209,7 +209,7 @@ getBotStartTime() {
                 sleep 1
             fi
         done
-        echo "waited. found: $first_bot_start_time" > /dev/stderr
+        echo "waited. found first start time: $first_bot_start_time" > /dev/stderr
         echo "$(( ($bot_number - 1) * $BOT_RAMPING_DELAY + $first_bot_start_time ))"
     fi
 }

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -50,6 +50,7 @@ getBotNumber() {
 #   "ticks":            100,            # number of ticks for each bot to deposit
 #   "fees":             [1, 5, 20, 100] # each LP deposit fee may be (randomly) one of the whitelisted fees here
 #   "gas":              "0untrn"        # additional gas tokens that bots can use to cover gas fees
+#   "rebalance_factor": 0.1,            # fraction of excessive deposits on either pair side to rebalance on each trade
 #   "deposit_factor":   0.1,            # fraction of the recommended maximum reserves to use on a single tick deposit
 #   "swap_factor":      0.1,            # max fraction of a bot's token reserves to use on a single swap trade (max: 1)
 #   "swap_accuracy":    100,            # ~1% of price:     swaps will target within ~1% of current price
@@ -109,6 +110,7 @@ getTokenConfigArray() {
                 price: (.value.price // $defaults.price // 1),
                 ticks: (.value.ticks // $defaults.ticks // 100),
                 fees: (.value.fees // $defaults.fees // [1, 5, 20, 100]),
+                rebalance_factor: (.value.rebalance_factor // $defaults.rebalance_factor // 0.1),
                 deposit_factor: (.value.deposit_factor // $defaults.deposit_factor // 0.1),
                 swap_factor: (.value.swap_factor // $defaults.swap_factor // 0.1),
                 swap_accuracy: (.value.swap_accuracy // $defaults.swap_accuracy // 100),

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -482,7 +482,7 @@ waitForTxResult() {
     if [ "$code" -ne "0" ]
     then
         log+=' '
-        log+="$( jq -r '"[ tx log: \(.raw_log) ]"' )"
+        log+="$( echo "$tx_response" | jq -r '"[ tx log: \(.raw_log) ]"' )"
     fi
     # add log descriptions if defined
     if [ "$code" -eq "0" ] && [ ! -z "$on_success_log" ]

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -50,9 +50,9 @@ getBotNumber() {
 #   "ticks":            100,            # number of ticks for each bot to deposit
 #   "fees":             [1, 5, 20, 100] # each LP deposit fee may be (randomly) one of the whitelisted fees here
 #   "gas":              "0untrn"        # additional gas tokens that bots can use to cover gas fees
-#   "rebalance_factor": 0.1,            # fraction of excessive deposits on either pair side to rebalance on each trade
-#   "deposit_factor":   0.1,            # fraction of the recommended maximum reserves to use on a single tick deposit
-#   "swap_factor":      0.1,            # max fraction of a bot's token reserves to use on a single swap trade (max: 1)
+#   "rebalance_factor": 0.5,            # fraction of excessive deposits on either pair side to rebalance on each trade
+#   "deposit_factor":   0.5,            # fraction of the recommended maximum reserves to use on a single tick deposit
+#   "swap_factor":      0.5,            # max fraction of a bot's token reserves to use on a single swap trade (max: 1)
 #   "swap_accuracy":    100,            # ~1% of price:     swaps will target within ~1% of current price
 #   "deposit_accuracy": 1000,           # ~10% of price:    deposits will target within ~10% of current price
 #   "amplitude1":       5000,           # ~50% of price:    current price will vary by ~50% of set price ratio
@@ -110,9 +110,9 @@ getTokenConfigArray() {
                 price: (.value.price // $defaults.price // 1),
                 ticks: (.value.ticks // $defaults.ticks // 100),
                 fees: (.value.fees // $defaults.fees // [1, 5, 20, 100]),
-                rebalance_factor: (.value.rebalance_factor // $defaults.rebalance_factor // 0.1),
-                deposit_factor: (.value.deposit_factor // $defaults.deposit_factor // 0.1),
-                swap_factor: (.value.swap_factor // $defaults.swap_factor // 0.1),
+                rebalance_factor: (.value.rebalance_factor // $defaults.rebalance_factor // 0.5),
+                deposit_factor: (.value.deposit_factor // $defaults.deposit_factor // 0.5),
+                swap_factor: (.value.swap_factor // $defaults.swap_factor // 0.5),
                 swap_accuracy: (.value.swap_accuracy // $defaults.swap_accuracy // 100),
                 deposit_accuracy: (.value.deposit_accuracy // $defaults.deposit_accuracy // 1000),
                 amplitude1: (.value.amplitude1 // $defaults.amplitude1 // 5000),

--- a/scripts/run_trade_bot.sh
+++ b/scripts/run_trade_bot.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
-set -e
+
+# by default allow errors: if an error is thrown during the simulation
+# it should be handled here and the simulation loop can `break` to exit
+set +e
 
 # make script path consistent
 SCRIPTPATH="$( dirname "$(readlink "$BASH_SOURCE" || echo "$BASH_SOURCE")" )"

--- a/scripts/run_trade_bot.sh
+++ b/scripts/run_trade_bot.sh
@@ -243,6 +243,7 @@ do
       | jq -r ".tick_liquidity[0].pool_reserves.price_taker_to_maker"
     )
     # use bc for aribtrary precision math comparison (check for null because non-zero result evals true)
+    echo "check: place-limit-order: token0 side: is $first_tick0_price_ratio > $goal_price_ratio ?"
     if [ "$first_tick0_price_ratio" != "null" ] && (( $( bc <<< "$first_tick0_price_ratio > $goal_price_ratio" ) ))
     then
       echo "making place-limit-order: '$token1' -> '$token0'"
@@ -271,6 +272,8 @@ do
       else
         echo "skipping place-limit-order: '$token1' -> '$token0': not enough funds"
       fi
+    else
+      echo "ignore place-limit-order: '$token1' -> '$token0': no liquidity to arbitrage"
     fi
     # find if there are tokens to swap in the other direction
     echo "making query: of current '$token1' ticks"
@@ -278,6 +281,7 @@ do
       neutrond query dex list-tick-liquidity "$token0<>$token1" "$token1" --output json --limit 1 \
       | jq -r ".tick_liquidity[0].pool_reserves.price_opposite_taker_to_maker"
     )
+    echo "check: place-limit-order: token1 side: is $first_tick1_price_ratio < $goal_price_ratio ?"
     if [ "$first_tick1_price_ratio" != "null" ] && (( $(bc <<< "$first_tick1_price_ratio < $goal_price_ratio") ))
     then
       echo "making place-limit-order: '$token0' -> '$token1'"
@@ -306,6 +310,8 @@ do
       else
         echo "skipping place-limit-order: '$token0' -> '$token1': not enough funds"
       fi
+    else
+      echo "ignore place-limit-order: '$token0' -> '$token1': no liquidity to arbitrage"
     fi
 
     # check if duration has been reached

--- a/scripts/run_trade_bot.sh
+++ b/scripts/run_trade_bot.sh
@@ -123,7 +123,7 @@ do
     break
   fi
 
-  echo "... loop will delay for: $delay"
+  echo "... loop will delay for: $delay seconds"
   sleep $delay
   echo "loop: starting at $EPOCHSECONDS"
 

--- a/scripts/run_trade_bot.sh
+++ b/scripts/run_trade_bot.sh
@@ -218,7 +218,7 @@ do
         `# list of fees` \
         "$( get_joined_array $tick_count get_fee "$fees" )" \
         `# disable_autoswap` \
-        "$(repeat_with_comma "false" "$tick_count")" \
+        "$( repeat_with_comma "true" "$tick_count" )" \
         `# options` \
         --from $person --yes --output json --broadcast-mode sync --gas auto --gas-adjustment $GAS_ADJUSTMENT --gas-prices $GAS_PRICES
       )"
@@ -384,7 +384,7 @@ do
       `# list of fees` \
       "$( get_joined_array $excess_user_deposits_count get_fee "$fees" )" \
       `# disable_autoswap` \
-      "$(repeat_with_comma "false" "$excess_user_deposits_count")" \
+      "$( repeat_with_comma "true" "$excess_user_deposits_count" )" \
       `# options` \
       --from $person --yes --output json --broadcast-mode sync --gas auto --gas-adjustment $GAS_ADJUSTMENT --gas-prices $GAS_PRICES
     )"

--- a/scripts/run_trade_bot.sh
+++ b/scripts/run_trade_bot.sh
@@ -227,7 +227,6 @@ do
     # compute goal price (and inverse gola price for inverted token pair order: token1<>token0)
     goal_price=$(( $current_price + $deviation ))
     goal_price_ratio=$( echo "1.0001^$goal_price" | bc -l )
-    inverse_goal_price=$(( $goal_price * -1 ))
 
     # - make a swap to get to current price
     echo "calculating: a swap on the pair '$token0' and '$token1'..."
@@ -255,7 +254,7 @@ do
           `# token out` \
           $token0 \
           `# tickIndexInToOut (note: this is the limit that we will swap up to, the goal)` \
-          "[$inverse_goal_price]" \
+          "[$(( $goal_price * -1 ))]" \
           `# amount in: allow up to a good fraction of the denom balance to be traded, to try to reach the tick limit` \
           "$trade_amount" \
           `# order type enum see: https://github.com/duality-labs/duality/blob/v0.2.1/proto/duality/dex/tx.proto#L81-L87` \

--- a/scripts/run_trade_bot.sh
+++ b/scripts/run_trade_bot.sh
@@ -95,17 +95,21 @@ two_pi=$( echo "scale=8; 8*a(1)" | bc -l )
 start_epoch=$( bash $SCRIPTPATH/helpers.sh getBotStartTime )
 sleep $(( $start_epoch - $EPOCHSECONDS > 0 ? $start_epoch - $EPOCHSECONDS : 0 ))
 
+TRADE_FREQUENCY_SECONDS="${TRADE_FREQUENCY_SECONDS:-60}"
+
 # add function to check when the script should finish
-end_epoch=$( bash $SCRIPTPATH/helpers.sh getBotEndTime )
+end_epoch=$( bash $SCRIPTPATH/helpers.sh getBotEndTime "$TRADE_FREQUENCY_SECONDS" )
 function check_duration {
   extra_time="${1:-0}"
-  if [ ! -z $end_epoch ] && [ $end_epoch -lt $(( $EPOCHSECONDS + $extra_time )) ]
+  if [ ! -z $end_epoch ]
   then
-    echo "duration reached";
+    echo "duration check: $(( $end_epoch - $EPOCHSECONDS )) seconds left to go" > /dev/stderr
+    if [ $end_epoch -lt $(( $EPOCHSECONDS + $extra_time )) ]
+    then
+      echo "duration reached";
+    fi
   fi
 }
-
-TRADE_FREQUENCY_SECONDS="${TRADE_FREQUENCY_SECONDS:-60}"
 
 # respond to price changes forever
 while true

--- a/scripts/run_trade_bot.sh
+++ b/scripts/run_trade_bot.sh
@@ -351,6 +351,9 @@ do
     token1_excess_user_deposits_count=$( echo "$token1_sorted_user_deposits" | jq -r "$excess_count_filter" )
     excess_user_deposits_count=$(( $token0_excess_user_deposits_count + $token1_excess_user_deposits_count ))
 
+    echo "rebalance $token0 -> $token1: will move $token0_excess_user_deposits_count ticks"
+    echo "rebalance $token1 -> $token0: will move $token1_excess_user_deposits_count ticks"
+
     # check if duration has been reached
     if [ ! -z "$( check_duration )" ]
     then
@@ -394,7 +397,7 @@ do
       | jq -r '.txhash' \
       | xargs -I{} bash $SCRIPTPATH/helpers.sh waitForTxResult $API_ADDRESS "{}" \
       | jq -r '"[ tx code: \(.tx_response.code) ] [ tx hash: \(.tx_response.txhash) ]"' \
-      | xargs -I{} echo "{} deposited: new close-to-price ticks ($excess_user_deposits_count)"
+      | xargs -I{} echo "{} deposited: new close-to-price ticks ($token1_excess_user_deposits_count, $token0_excess_user_deposits_count)"
 
     # check if duration has been reached
     if [ ! -z "$( check_duration )" ]

--- a/scripts/run_trade_bot.sh
+++ b/scripts/run_trade_bot.sh
@@ -240,10 +240,10 @@ do
     echo "making query: of current '$token0' ticks"
     first_tick0_price_ratio=$(
       neutrond query dex list-tick-liquidity "$token0<>$token1" "$token0" --output json --limit 1 \
-      | jq ".tick_liquidity[0].pool_reserves.key.price_taker_to_maker"
+      | jq -r ".tick_liquidity[0].pool_reserves.price_taker_to_maker"
     )
-    # use bc for aribtrary precision math comparison (non-zero result evals true)
-    if (( $( bc <<< "$first_tick0_price_ratio > $goal_price_ratio" ) ))
+    # use bc for aribtrary precision math comparison (check for null because non-zero result evals true)
+    if [ "$first_tick0_price_ratio" != "null" ] && (( $( bc <<< "$first_tick0_price_ratio > $goal_price_ratio" ) ))
     then
       echo "making place-limit-order: '$token1' -> '$token0'"
       trade_amount="$( neutrond query bank balances $address --denom $token1 --output json | jq -r "(.amount | tonumber) * $swap_factor | floor" )"
@@ -276,9 +276,9 @@ do
     echo "making query: of current '$token1' ticks"
     first_tick1_price_ratio=$(
       neutrond query dex list-tick-liquidity "$token0<>$token1" "$token1" --output json --limit 1 \
-      | jq ".tick_liquidity[0].pool_reserves.key.price_opposite_taker_to_maker"
+      | jq -r ".tick_liquidity[0].pool_reserves.price_opposite_taker_to_maker"
     )
-    if (( $(bc <<< "$first_tick1_price_ratio < $goal_price_ratio") ))
+    if [ "$first_tick1_price_ratio" != "null" ] && (( $(bc <<< "$first_tick1_price_ratio < $goal_price_ratio") ))
     then
       echo "making place-limit-order: '$token0' -> '$token1'"
       trade_amount="$( neutrond query bank balances $address --denom $token0 --output json | jq -r "(.amount | tonumber) * $swap_factor | floor" )"

--- a/scripts/run_trade_bot.sh
+++ b/scripts/run_trade_bot.sh
@@ -134,6 +134,7 @@ do
     # convert price to price index here
     price_index=$( echo "$token_pair_config" | jq -r '((.price | log)/(1.0001 | log) | round)' )
     fees=$( echo "$token_pair_config" | jq -r '.fees' )
+    deposit_factor=$( echo "$token_pair_config" | jq -r '.deposit_factor' )
     swap_factor=$( echo "$token_pair_config" | jq -r '.swap_factor' )
     deposit_index_accuracy=$( echo "$token_pair_config" | jq -r '.deposit_accuracy' )
     swap_index_accuracy=$( echo "$token_pair_config" | jq -r '.swap_accuracy' )
@@ -152,8 +153,11 @@ do
     # in general terms this is:
     #     - deposited = available / (bot_count+1) / 2
     #     -  reserves = available - deposited
-    token0_initial_deposit_amount="$(( $token0_total_amount / ($bot_count + 1) / 2 ))"
-    token1_initial_deposit_amount="$(( $token1_total_amount / ($bot_count + 1) / 2 ))"
+    token0_max_initial_deposit_amount="$(( $token0_total_amount / ($bot_count + 1) / 2 ))"
+    token1_max_initial_deposit_amount="$(( $token1_total_amount / ($bot_count + 1) / 2 ))"
+    token0_initial_deposit_amount=$( echo " $token0_max_initial_deposit_amount * $deposit_factor " | bc -l | awk '{print int($1+0.5)}' )
+    token1_initial_deposit_amount=$( echo " $token1_max_initial_deposit_amount * $deposit_factor " | bc -l | awk '{print int($1+0.5)}' )
+
     # the amount of a single this is the deposit amount spread across the ticks on one side
     token0_single_tick_deposit_amount="$(( $token0_initial_deposit_amount / $tick_count_on_each_side ))"
     token1_single_tick_deposit_amount="$(( $token1_initial_deposit_amount / $tick_count_on_each_side ))"

--- a/scripts/run_trade_bot.sh
+++ b/scripts/run_trade_bot.sh
@@ -236,7 +236,7 @@ do
     # then swap those reserves
     echo "making query: of current '$token0' ticks"
     first_tick0_price_ratio=$(
-      neutrond query dex list-tick-liquidity "$token0<>$token1" "$token0" --output json --limit 100 \
+      neutrond query dex list-tick-liquidity "$token0<>$token1" "$token0" --output json --limit 1 \
       | jq ".tick_liquidity[0].pool_reserves.key.price_taker_to_maker"
     )
     # use bc for aribtrary precision math comparison (non-zero result evals true)
@@ -281,7 +281,7 @@ do
     else
       echo "making query: of current '$token1' ticks"
       first_tick1_price_ratio=$(
-        neutrond query dex list-tick-liquidity "$token0<>$token1" "$token1" --output json --limit 100 \
+        neutrond query dex list-tick-liquidity "$token0<>$token1" "$token1" --output json --limit 1 \
         | jq ".tick_liquidity[0].pool_reserves.key.price_opposite_taker_to_maker"
       )
       if (( $(bc <<< "$first_tick1_price_ratio < $goal_price_ratio") ))

--- a/scripts/setup_fund_users.sh
+++ b/scripts/setup_fund_users.sh
@@ -52,7 +52,7 @@ then
     then
         send_or_multi_send="multi-send"
     fi
-    response=$(
+    tx_response=$(
         neutrond tx bank $send_or_multi_send \
             "$( neutrond keys show $funder -a )" \
             "${user_addresses_array[@]}" \
@@ -64,18 +64,9 @@ then
             --gas-prices $GAS_PRICES \
             --yes
     )
-    if [ "$( echo $response | jq -r '.code' )" -eq "0" ]
-    then
-        tx_hash=$( echo $response | jq -r '.txhash' )
-        # get tx result for msg
-        tx_result=$( bash $SCRIPTPATH/helpers.sh waitForTxResult "$API_ADDRESS" "$tx_hash" )
-        if [ "$( echo "$tx_result" | jq -r '.tx_response.code' )" -eq "0" ]
-        then
-            echo "funded users: ${user_addresses_array[@]} with tokens $tokens"
-        else
-            echo "funding user error (code: $( echo $response | jq -r '.tx_response.code' )): $( echo $response | jq -r '.tx_response.raw_log' )" > /dev/stderr
-        fi
-    else
-        echo "funding user error (code: $( echo $response | jq -r '.code' )): $( echo $response | jq -r '.raw_log' )" > /dev/stderr
-    fi
+    tx_result="$(
+        bash $SCRIPTPATH/helpers.sh waitForTxResult "$tx_response" \
+        "funded users: ${user_addresses_array[@]} with tokens $tokens" \
+        "funding user error: for ${user_addresses_array[@]} with tokens $tokens"
+    )"
 fi


### PR DESCRIPTION
this PR improves the overall behavior of the trade simulations

## Previously
- the simulation could easily "run out" of tokens to swap with when the price drifted significantly
    - this is because the bots would swap through all the liquidity in one direction, leaving almost none of one token side
    - this would eventually be corrected when the price came back within range, leaving large gaps of price activity
- "behind enemy lines" pools were common as the bots ignored liquidity in the opposite direction of the moving price

previous simulation liquidity behavior (video sped up), run using command:
```
make start-trade-bot \
    BOTS=3 \
    TRADE_FREQUENCY_SECONDS=0 \
    TRADE_DURATION_SECONDS=7200 \
    MNEMONICS="
    banner spread envelope side kite person disagree path silver will brother under couch edit food venture squirrel civil budget number acquire point work mass;
    veteran try aware erosion drink dance decade comic dawn museum release episode original list ability owner size tuition surface ceiling depth seminar capable only;
    obscure canal because tomorrow tribe sibling describe satoshi kiwi upgrade bless empty math trend erosion oblige donate label birth chronic hazard ensure wreck shine;
    " \
    TOKEN_CONFIG='{"10000000000000uibcatom<>10000000000000uibcusdc":0.1,"100000000000uibcusdc<>100000000000untrn":{"price":2,"ticks":50},"1000000000uibcatom<>1000000000untrn":{"price":0.2,"ticks":30},"defaults":{"fees":[0,1,2,3,4,5,10,20,50,100,150,200],"gas":"1000000000untrn","period1":3600}}'
``` 

Note: this simulation uses the demo wallets directly so that the users in this simulation won't run out of tokens as was fixed in commit [8fc5957](https://github.com/neutron-org/dex-trading-bot/pull/5/commits/8fc5957c34af3f722ca537e5dca77f1e5d81aa23)

https://github.com/neutron-org/dex-trading-bot/assets/6194521/ac27a7ec-84eb-4db4-9f60-d60b058adc01

<img width="1728" alt="Screenshot 2024-03-05 at 3 04 19 pm" src="https://github.com/neutron-org/dex-trading-bot/assets/6194521/64fca980-2022-4d7c-85aa-bf03720f6e6f">

## These changes
this has been corrected with:
- swapping in both directions to pick up deposits that would be "behind enemy lines" like any good arbitrager would do
- added in "rebalance" logic: when a bot's pools are uneven across a pair (eg. 40 ticks vs 5 ticks)
    - the number of ticks moved is now dynamic: several ticks may be removed from one side, and new ticks will be deposited on the other side to make the deposits more even
    - when a price changes significantly the bots will act like good LPs and shift their ticks closer to the active price
- `deposit_factor` gives more control around how much liquidity is deposited in pools (to avoid swapping all reserves)
- `swap_factor` gives more control around how aggressive swapping is (to avoid swapping all reserves)
- `rebalance_factor` gives more control around how many ticks should be rebalanced each cycle
    - a high `rebalance_factor` will rebalance more aggressively, making the deposits follow the price more "tightly"

new simulation liquidity behavior (video sped up), run using the same setup as the previous simulation: 

https://github.com/neutron-org/dex-trading-bot/assets/6194521/c4372517-cd48-4487-83de-797eea1461dd

<img width="1728" alt="Screenshot 2024-03-27 at 2 43 52 PM" src="https://github.com/neutron-org/dex-trading-bot/assets/6194521/edd8ac0c-894d-4d15-8aa9-1f06d2f7ca41">
