### PR TITLE
[NTRN-272] feat: real price mirroring using coingecko

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ All docker-compose env vars are able to be set in both `make start-trade-bot` an
     - `GAS_ADJUSTMENT`: how much more than the base estimated gas price to pay for each tx
     - `GAS_PRICES`: calculate how many fees to pay from this fraction of gas
     - `TOKEN_CONFIG`: a token pairs configuration (JSON) object for eg. token amounts to trade
-        - see [helpers.sh](https://github.com/neutron-org/dex-trading-bot/blob/6405de231be4cb7a40faa460ba2816162afb9848/scripts/helpers.sh#L41-L63) for more setting details
+        - see [helpers.sh](https://github.com/neutron-org/dex-trading-bot/blob/131a5f1590483840305cb475f8a867996509333e/scripts/helpers.sh#L41-L63) for more setting details
     - mnemonics:
         - `FAUCET_MNEMONIC` (optional): the mnemonic of the account that will fund generated bots
         - `BOT_MNEMONIC/S` or `MNEMONIC/S` (optional): the mnemonics for self-funded bot account(s)

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ All docker-compose env vars are able to be set in both `make start-trade-bot` an
     - `GAS_ADJUSTMENT`: how much more than the base estimated gas price to pay for each tx
     - `GAS_PRICES`: calculate how many fees to pay from this fraction of gas
     - `TOKEN_CONFIG`: a token pairs configuration (JSON) object for eg. token amounts to trade
-        - see [helpers.sh](https://github.com/neutron-org/dex-trading-bot/blob/e0f6f7128182b9dce2a54abbee279219ae8dc9fc/scripts/helpers.sh#L41-L63) for more setting details
+        - see [helpers.sh](https://github.com/neutron-org/dex-trading-bot/blob/6405de231be4cb7a40faa460ba2816162afb9848/scripts/helpers.sh#L41-L63) for more setting details
     - mnemonics:
         - `FAUCET_MNEMONIC` (optional): the mnemonic of the account that will fund generated bots
         - `BOT_MNEMONIC/S` or `MNEMONIC/S` (optional): the mnemonics for self-funded bot account(s)

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ All docker-compose env vars are able to be set in both `make start-trade-bot` an
     - `GAS_ADJUSTMENT`: how much more than the base estimated gas price to pay for each tx
     - `GAS_PRICES`: calculate how many fees to pay from this fraction of gas
     - `TOKEN_CONFIG`: a token pairs configuration (JSON) object for eg. token amounts to trade
-        - see [helpers.sh](https://github.com/neutron-org/dex-trading-bot/blob/e0f6f7128182b9dce2a54abbee279219ae8dc9fc/scripts/helpers.sh#L41-L59) for more setting details
+        - see [helpers.sh](https://github.com/neutron-org/dex-trading-bot/blob/e0f6f7128182b9dce2a54abbee279219ae8dc9fc/scripts/helpers.sh#L41-L63) for more setting details
     - mnemonics:
         - `FAUCET_MNEMONIC` (optional): the mnemonic of the account that will fund generated bots
         - `BOT_MNEMONIC/S` or `MNEMONIC/S` (optional): the mnemonics for self-funded bot account(s)

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ All docker-compose env vars are able to be set in both `make start-trade-bot` an
         - `BOT_MNEMONIC/S` or `MNEMONIC/S` (optional): the mnemonics for self-funded bot account(s)
         - at least one of `FAUCET_MNEMONIC` or `BOT_/MNEMONIC/S` should be provided
         - with a local chain you can use `DEMO_MNEMONIC`s from the neutron networks/init.sh file
-    - `COINGECKO_API_TOKEN`: a Coingecko API token used for live prices fetching. Only used with pespective token pair price setting. Keep in mind the [rate limits for different types of Coingecko API tokens](https://www.coingecko.com/en/api/pricing).
+    - `COINGECKO_API_TOKEN`: a Coingecko API token used for live prices fetching. Only used with respective token pair price setting. The token should be a [demo API token](https://www.coingecko.com/en/api/pricing). Pro tokens aren't supported because they use different endpoints. Keep in mind the very limited request rate the demo tokens provide when configuring the bots number and trading intensity.
 
 eg. `make start-trade-bot BOTS=30 BOT_RAMPING_DELAY=5 TRADE_FREQUENCY_SECONDS=0 TRADE_DURATION_SECONDS=450 MNEMONIC=...`
 will start a persistent chain that for the first ~10min (7min+ramping) will generate ~5000txs using 30 bots.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ All docker-compose env vars are able to be set in both `make start-trade-bot` an
         - `BOT_MNEMONIC/S` or `MNEMONIC/S` (optional): the mnemonics for self-funded bot account(s)
         - at least one of `FAUCET_MNEMONIC` or `BOT_/MNEMONIC/S` should be provided
         - with a local chain you can use `DEMO_MNEMONIC`s from the neutron networks/init.sh file
-    - `COINGECKO_API_TOKEN`: a Coingecko API token used for live prices fetching (only used with pespective token pair price setting)
+    - `COINGECKO_API_TOKEN`: a Coingecko API token used for live prices fetching. Only used with pespective token pair price setting. Keep in mind the [rate limits for different types of Coingecko API tokens](https://www.coingecko.com/en/api/pricing).
 
 eg. `make start-trade-bot BOTS=30 BOT_RAMPING_DELAY=5 TRADE_FREQUENCY_SECONDS=0 TRADE_DURATION_SECONDS=450 MNEMONIC=...`
 will start a persistent chain that for the first ~10min (7min+ramping) will generate ~5000txs using 30 bots.

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ All docker-compose env vars are able to be set in both `make start-trade-bot` an
         - `BOT_MNEMONIC/S` or `MNEMONIC/S` (optional): the mnemonics for self-funded bot account(s)
         - at least one of `FAUCET_MNEMONIC` or `BOT_/MNEMONIC/S` should be provided
         - with a local chain you can use `DEMO_MNEMONIC`s from the neutron networks/init.sh file
+    - `COINGECKO_API_TOKEN`: a Coingecko API token used for live prices fetching (only used with pespective token pair price setting)
 
 eg. `make start-trade-bot BOTS=30 BOT_RAMPING_DELAY=5 TRADE_FREQUENCY_SECONDS=0 TRADE_DURATION_SECONDS=450 MNEMONIC=...`
 will start a persistent chain that for the first ~10min (7min+ramping) will generate ~5000txs using 30 bots.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,6 +87,7 @@ services:
             "gas":"1000000000untrn"
           }
         }
+      - COIGECKO_API_TOKEN=${COIGECKO_API_TOKEN}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,7 +87,7 @@ services:
             "gas":"1000000000untrn"
           }
         }
-      - COIGECKO_API_TOKEN=${COIGECKO_API_TOKEN}
+      - COINGECKO_API_TOKEN=${COINGECKO_API_TOKEN}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     networks:

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -47,7 +47,7 @@ getBotNumber() {
 # the object values are the price ratio of tokenB/tokenA, a coingecko pair or a config object: (default values are listed)
 # PAIR_CONFIG = {
 #   "price":            1,                              # price ratio is of tokenB/tokenA (how many tokenA is required to buy 1 tokenB?), OR
-#   "price":            "coingecko:api_id0<>api_id1",   # for live price retrieval, use the coingecko API IDs of the tokens (e.g. "coingecko:cosmos<>neutron-3" for atom<>ntrn pair)
+#   "price":            "coingecko:api_idA<>api_idB",   # for live price retrieval, use the coingecko API IDs of the tokens (e.g. "coingecko:cosmos<>neutron-3" for atom<>ntrn pair)
 #   "ticks":            100,                            # number of ticks for each bot to deposit
 #   "fees":             [1, 5, 20, 100]                 # each LP deposit fee may be (randomly) one of the whitelisted fees here
 #   "gas":              "0untrn"                        # additional gas tokens that bots can use to cover gas fees

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -44,21 +44,22 @@ getBotNumber() {
 #   "defaults": PAIR_CONFIG
 # }
 # the object keys are the usable tokens for each pair (to be shared across all bots),
-# the object values are the price ratio of token1/token0 or a config object: (default values are listed)
+# the object values are the price ratio of token1/token0, a coingecko pair or a config object: (default values are listed)
 # PAIR_CONFIG = {
-#   "price":            1,              # price ratio is of token1/token0 (how many token0 is required to buy 1 token1?)
-#   "ticks":            100,            # number of ticks for each bot to deposit
-#   "fees":             [1, 5, 20, 100] # each LP deposit fee may be (randomly) one of the whitelisted fees here
-#   "gas":              "0untrn"        # additional gas tokens that bots can use to cover gas fees
-#   "rebalance_factor": 0.5,            # fraction of excessive deposits on either pair side to rebalance on each trade
-#   "deposit_factor":   0.5,            # fraction of the recommended maximum reserves to use on a single tick deposit
-#   "swap_factor":      0.5,            # max fraction of a bot's token reserves to use on a single swap trade (max: 1)
-#   "swap_accuracy":    100,            # ~1% of price:     swaps will target within ~1% of current price
-#   "deposit_accuracy": 1000,           # ~10% of price:    deposits will target within ~10% of current price
-#   "amplitude1":       5000,           # ~50% of price:    current price will vary by ~50% of set price ratio
-#   "period1":          36000,          # ten hours:        current price will cycle min->max->min every ten hours
-#   "amplitude2":       1000,           # ~10% of price:    current price will vary by an additional ~10% of price ratio
-#   "period2":          600,            # ten minutes:      current price will cycle amplitude2 offset every ten minutes
+#   "price":            1,                              # price ratio is of token1/token0 (how many token0 is required to buy 1 token1?), OR
+#   "price":            "coingecko:api_id0<>api_id1",   # for live price retrieval, use the coingecko API IDs of the tokens (e.g. "coingecko:cosmos<>neutron-3" for atom<>ntrn pair)
+#   "ticks":            100,                            # number of ticks for each bot to deposit
+#   "fees":             [1, 5, 20, 100]                 # each LP deposit fee may be (randomly) one of the whitelisted fees here
+#   "gas":              "0untrn"                        # additional gas tokens that bots can use to cover gas fees
+#   "rebalance_factor": 0.5,                            # fraction of excessive deposits on either pair side to rebalance on each trade
+#   "deposit_factor":   0.5,                            # fraction of the recommended maximum reserves to use on a single tick deposit
+#   "swap_factor":      0.5,                            # max fraction of a bot's token reserves to use on a single swap trade (max: 1)
+#   "swap_accuracy":    100,                            # ~1% of price:     swaps will target within ~1% of current price
+#   "deposit_accuracy": 1000,                           # ~10% of price:    deposits will target within ~10% of current price
+#   "amplitude1":       5000,                           # ~50% of price:    current price will vary by ~50% of set price ratio
+#   "period1":          36000,                          # ten hours:        current price will cycle min->max->min every ten hours
+#   "amplitude2":       1000,                           # ~10% of price:    current price will vary by an additional ~10% of price ratio
+#   "period2":          600,                            # ten minutes:      current price will cycle amplitude2 offset every ten minutes
 # }
 # which is transformed to format for token_config_array = [
 #   {

--- a/scripts/run_trade_bot.sh
+++ b/scripts/run_trade_bot.sh
@@ -153,7 +153,7 @@ do
     # if price is a number, i.e. if price is set manually
     if (( $(echo "$price_config" | grep -c '^[0-9]\+\(\.[0-9]\+\)\?$') == 1 ))
     then
-      echo "crafting $token0<>$token1 price using config approximation params" > /dev/stderr
+      echo "crafting $token0<>$token1 price using config approximation params"
 
       # pair simulation options
       amplitude1=$( echo "$token_pair_config" | jq -r '.amplitude1' )
@@ -163,7 +163,7 @@ do
 
       # convert price to price index here
       price_index=$( echo "$token_pair_config" | jq -r '((.price | log)/(1.0001 | log) | round)' )
-      echo "calculated price index before approximation $price_index" > /dev/stderr
+      echo "calculated price index before approximation $price_index"
 
       # determine the new current price goal
       # approximate price with sine curves of given amplitude and period
@@ -181,25 +181,25 @@ do
         api_id0="${BASH_REMATCH[1]}"
         api_id1="${BASH_REMATCH[2]}"
       else
-        echo "error: unexpected coingecko price format $price_config" > /dev/stderr
+        echo "error: unexpected coingecko price format $price_config"
         exit 1
       fi
 
       api_token="${COINGECKO_API_TOKEN}"
       if [[ -z $api_token ]]
       then
-        echo "error: coingecko API token is not provided" > /dev/stderr
+        echo "error: coingecko API token is not provided"
         exit 1
       fi
       
-      echo "getting $token0 ($api_id0) and $token1 ($api_id1) prices from coingecko" > /dev/stderr
+      echo "getting $token0 ($api_id0) and $token1 ($api_id1) prices from coingecko"
 
       # get token0 price in usd
       price0_resp=$(curl -s "https://api.coingecko.com/api/v3/coins/markets?vs_currency=usd&ids=$api_id0&x_cg_demo_api_key=$api_token")
       price0=$(echo $price0_resp | jq -r '.[0].current_price')
       if (( $(echo "$price0" | grep -c '^[0-9]\+\(\.[0-9]\+\)\?$') == 0 )) # expected a number
       then
-        echo "failed to get current $token0 price price from coingecko response: $price0_resp" > /dev/stderr
+        echo "failed to get current $token0 price price from coingecko response: $price0_resp"
         exit 1
       fi
 
@@ -208,21 +208,21 @@ do
       price1=$(echo $price1_resp | jq -r '.[0].current_price')
       if (( $(echo "$price1" | grep -c '^[0-9]\+\(\.[0-9]\+\)\?$') == 0 )) # expected a number
       then
-        echo "failed to get current $token1 price price from coingecko response: $price1_resp" > /dev/stderr
+        echo "failed to get current $token1 price price from coingecko response: $price1_resp"
         exit 1
       fi
 
-      echo "got prices: $token0 = $price0, $token1 = $price1" > /dev/stderr
+      echo "got prices: $token0 = $price0, $token1 = $price1"
 
       # convert assets price ratio to price index here
       current_price=$(
         rounded_calculation \
         "l($price1/$price0) / l(1.0001)"
       )
-      echo "calculated price index $current_price" > /dev/stderr
+      echo "calculated price index $current_price"
 
     else
-      echo "error: unexpected $token0<>$token1 price format $price_config: expected a number or a coingecko pair" > /dev/stderr
+      echo "error: unexpected $token0<>$token1 price format $price_config: expected a number or a coingecko pair"
       exit 1
     fi
 

--- a/scripts/run_trade_bot.sh
+++ b/scripts/run_trade_bot.sh
@@ -185,7 +185,7 @@ do
         exit 1
       fi
 
-      api_token="${COIGECKO_API_TOKEN}"
+      api_token="${COINGECKO_API_TOKEN}"
       if [[ -z $api_token ]]
       then
         echo "error: coingecko API token is not provided" > /dev/stderr

--- a/scripts/run_trade_bot.sh
+++ b/scripts/run_trade_bot.sh
@@ -191,24 +191,21 @@ do
         echo "error: coingecko API token is not provided"
         exit 1
       fi
-      
+
       echo "getting $token0 ($api_id0) and $token1 ($api_id1) prices from coingecko"
 
-      # get token0 price in usd
-      price0_resp=$(curl -s "https://api.coingecko.com/api/v3/coins/markets?vs_currency=usd&ids=$api_id0&x_cg_demo_api_key=$api_token")
-      price0=$(echo $price0_resp | jq -r '.[0].current_price')
+      # get token prices in usd
+      prices_resp=$(curl -s "https://api.coingecko.com/api/v3/coins/markets?vs_currency=usd&ids=$api_id0,$api_id1&x_cg_demo_api_key=$api_token")
+      price0=$(echo $prices_resp | jq -r '.[] | select(.id == "'"$api_id0"'") | .current_price')
       if (( $(echo "$price0" | grep -c '^[0-9]\+\(\.[0-9]\+\)\?$') == 0 )) # expected a number
       then
-        echo "failed to get current $token0 price price from coingecko response: $price0_resp"
+        echo "failed to get current $token0 price from coingecko response: $prices_resp"
         exit 1
       fi
-
-      # get token1 price in usd
-      price1_resp=$(curl -s "https://api.coingecko.com/api/v3/coins/markets?vs_currency=usd&ids=$api_id1&x_cg_demo_api_key=$api_token")
-      price1=$(echo $price1_resp | jq -r '.[0].current_price')
+      price1=$(echo $prices_resp | jq -r '.[] | select(.id == "'"$api_id1"'") | .current_price')
       if (( $(echo "$price1" | grep -c '^[0-9]\+\(\.[0-9]\+\)\?$') == 0 )) # expected a number
       then
-        echo "failed to get current $token1 price price from coingecko response: $price1_resp"
+        echo "failed to get current $token1 price from coingecko response: $prices_resp"
         exit 1
       fi
 


### PR DESCRIPTION
#### task:
https://hadronlabs.atlassian.net/browse/NTRN-272

#### this PR:
- allows live price fetching option in addition to manual setting via a number:
```
make start-trade-bot \
    ... \
    TOKEN_CONFIG='{"1000untrn<>1000uibcusdc":{"price":"coingecko:neutron-3<>axelar-bridged-usdc-cosmos"}}'
```