### PR TITLE
fix: deposit index calculation

### DIFF
--- a/scripts/run_trade_bot.sh
+++ b/scripts/run_trade_bot.sh
@@ -458,7 +458,7 @@ do
       "[$(
         get_joined_array $tokenB_excess_user_deposits_count get_unique_integers_between $(( $current_price - $deposit_index_accuracy )) $(( $current_price - $swap_index_accuracy ))
       ),$(
-        get_joined_array $tokenA_excess_user_deposits_count get_unique_integers_between $(( $current_price + $deposit_index_accuracy )) $(( $current_price + $swap_index_accuracy ))
+        get_joined_array $tokenA_excess_user_deposits_count get_unique_integers_between $(( $current_price + $swap_index_accuracy )) $(( $current_price + $deposit_index_accuracy ))
       )]" \
       `# list of fees` \
       "$( get_joined_array $excess_user_deposits_count get_fee "$fees" )" \


### PR DESCRIPTION
The main fix is in 52ccccd4e3c9df90d1981e393e8b32ea0d58b68a

The send set of deposit indexes was incorrect because the function `get_unique_integers_between` expects the parameters to be ordered as `get_unique_integers_between $lower $upper`, however the values were being passed as `get_unique_integers_between $upper $lower` (because `swap_index_accuracy` should always be smaller than `deposit_index_accuracy`) so the deposits occurred at higher indexes than expected.

The second commit refactors the code slightly allowing these indexes to be logged and seen. 